### PR TITLE
Fixes for move constructors and assignment operators added for VS2013

### DIFF
--- a/tz.h
+++ b/tz.h
@@ -208,7 +208,7 @@ public:
     Zone(Zone&& src)
     :
         name_(std::move(src.name_)),
-		zonelets_(std::move(src.zonelets_))
+        zonelets_(std::move(src.zonelets_))
     {}
 
     Zone& operator=(Zone&& src)
@@ -582,28 +582,28 @@ struct TZ_DB
 #else  // defined(_MSC_VER) || (_MSC_VER >= 1900)
     TZ_DB(TZ_DB&& src)
     :
-		version(std::move(src.version)),
+        version(std::move(src.version)),
         zones(std::move(src.zones)),
-		links(std::move(src.links)),
-		leaps(std::move(src.leaps)),
-		rules(std::move(src.rules))
+        links(std::move(src.links)),
+        leaps(std::move(src.leaps)),
+        rules(std::move(src.rules))
 #if TIMEZONE_MAPPING
         ,
-		mappings(std::move(src.mappings)),
-		native_zones(std::move(src.native_zones))
+        mappings(std::move(src.mappings)),
+        native_zones(std::move(src.native_zones))
 #endif
     {}
 
     TZ_DB& operator=(TZ_DB&& src)
     {
-		version = std::move(src.version);
+        version = std::move(src.version);
         zones = std::move(src.zones);
-		links = std::move(src.links);
-		leaps = std::move(src.leaps);
-		rules = std::move(src.rules);
+        links = std::move(src.links);
+        leaps = std::move(src.leaps);
+        rules = std::move(src.rules);
 #if TIMEZONE_MAPPING
-		mappings = std::move(src.mappings);
-		native_zones = std::move(src.native_zones);
+        mappings = std::move(src.mappings);
+        native_zones = std::move(src.native_zones);
 #endif
         return *this;
     }

--- a/tz.h
+++ b/tz.h
@@ -208,7 +208,7 @@ public:
     Zone(Zone&& src)
     :
         name_(std::move(src.name_)),
-        zonelets_(std::move(zonelets_))
+		zonelets_(std::move(src.zonelets_))
     {}
 
     Zone& operator=(Zone&& src)
@@ -582,26 +582,28 @@ struct TZ_DB
 #else  // defined(_MSC_VER) || (_MSC_VER >= 1900)
     TZ_DB(TZ_DB&& src)
     :
+		version(std::move(src.version)),
         zones(std::move(src.zones)),
-        links(std::move(links)),
-        leaps(std::move(leaps)),
-        rules(std::move(rules))
+		links(std::move(src.links)),
+		leaps(std::move(src.leaps)),
+		rules(std::move(src.rules))
 #if TIMEZONE_MAPPING
         ,
-        mappings(std::move(mappings)),
-        native_zones(std::move(native_zones))
+		mappings(std::move(src.mappings)),
+		native_zones(std::move(src.native_zones))
 #endif
     {}
 
     TZ_DB& operator=(TZ_DB&& src)
     {
+		version = std::move(src.version);
         zones = std::move(src.zones);
-        links = std::move(links);
-        leaps = std::move(leaps);
-        rules = std::move(rules);
+		links = std::move(src.links);
+		leaps = std::move(src.leaps);
+		rules = std::move(src.rules);
 #if TIMEZONE_MAPPING
-        mappings = std::move(mappings);
-        native_zones = std::move(native_zones);
+		mappings = std::move(src.mappings);
+		native_zones = std::move(src.native_zones);
 #endif
         return *this;
     }


### PR DESCRIPTION
I believe move constructors and assignment operators added by ivanp2015 to be able to compile under VS2013 are flawed and need to be fixed (apart from name in Zone and zones in TZ_DB other members are not initialized correctly!).