### PR TITLE
mapping file suggested changes.

### DIFF
--- a/test/tz_test/validate.cpp
+++ b/test/tz_test/validate.cpp
@@ -83,8 +83,8 @@ test_info(const date::time_zone* zone, const date::sys_info& info)
     }
 }
 
-int
-main()
+void
+tzmain()
 {
     using namespace date;
     using namespace std::chrono;
@@ -142,4 +142,19 @@ main()
         }
         std::cout << '\n';
     }
+}
+
+int
+main()
+{
+    try
+    {
+        tzmain();
+    }
+    catch(const std::exception& ex)
+    {
+        std::cout << "An exception occured: " << ex.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This patch tries to make the mapping file parsing more flexible on Windows by opening it in text mode.
The thinking is this will allow crlf or lf line endings to be managed by the CRT which means when the file is pulled from github it should work "as is" either way.

It also fixes a bug where the line number for error reporting wasn't accounting for the copyright notice.
Finally the patch attempts to slightly formalize that a notice should exist and be at least 3 lines followed by a blank line. That should allow the app to diagnose if someone removes the copyright and stop the app from silently dropping the few lines of time zone data instead etc.

The patch also has a change to the tz test validate program so that it issues an error message when exceptions are thrown. Otherwise when compiled with MS's cl.exe compiler, no error is printed as by default MS's runtime does not print exceptions like the gnu runtime does so on error nothing appears on the command prompt when things like the mapping file is not found or there is a parsing error.