### PR TITLE
Work in progress patch to support Windows support for HAS_REMOTE_API …

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -25,7 +25,7 @@
 // been invented (that woud involve another several millennia of evolution).
 // We did not mean to shout.
 
-#ifdef _WIN32
+#if _WIN32
 // Windows.h will be included directly and indirectly (e.g. by curl).
 // We don't need everything Windows.h has to offer though and some
 // things like min/max will prevent compilation.
@@ -57,7 +57,7 @@
 #include <vector>
 #include <sys/stat.h>
 
-#ifdef _WIN32
+#if _WIN32
 #include <locale>
 #include <codecvt>
 #include <direct.h> // _mkdir
@@ -67,11 +67,11 @@
 // the current time zone. On Win32 Windows.h provides a means to do it.
 // gcc/mingw supports unistd.h on Win32 but MSVC does not.
 
-#ifdef _WIN32
+#if _WIN32
 #include <Windows.h>
 #include <io.h>
-#if HAS_REMOTE_API
 #include <ShlObj.h> // CoTaskFree, ShGetKnownFolderPath etc.
+#if HAS_REMOTE_API
 #include <Shellapi.h> // ShFileOperation etc.
 #endif
 #else
@@ -87,7 +87,7 @@
 
 #if TIMEZONE_MAPPING
 // See comments in tz.h regarding the XML mapping file.
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #endif
 
 namespace date
@@ -97,7 +97,7 @@ namespace date
 // +---------------------+
 
 // Until filesystem arrives.
-#ifdef _WIN32
+#if _WIN32
     static CONSTDATA char folder_delimiter = '\\';
 #else
     static CONSTDATA char folder_delimiter = '/';
@@ -143,17 +143,16 @@ namespace date
     {
         return get_known_folder(FOLDERID_ProgramFiles);
     }
-#endif
-
-#if HAS_REMOTE_API
-
-#if _WIN32
-
+    
     static std::string get_download_folder()
     {
         return get_known_folder(FOLDERID_Downloads);
     }
+#endif
 
+#if _WIN32
+
+#if HAS_REMOTE_API
     // Note folder can and usually does contain spaces.
     // Note assume's 7 zip is in the default installation location.
     // TODO! consider more certain means of finding it such as looking in the registry.
@@ -165,6 +164,7 @@ namespace date
         path += "7-Zip\\7z.exe";
         return path;
     }
+#endif // HAS_REMOTE_API
 
 #if TIMEZONE_MAPPING
     static std::vector<date::detail::timezone_mapping> load_zone_mappings_from_xml_file(const std::string& input_path)
@@ -210,7 +210,7 @@ namespace date
             return false;
         });
     }
-#endif
+#endif // TIMEZONE_MAPPING
 
 #else  // !_WIN32
     static
@@ -292,14 +292,14 @@ static_assert(min_year <= max_year, "Configuration error");
 
 static bool file_exists(const std::string& filename)
 {
-#ifdef _WIN32
+#if _WIN32
     return ::_access(filename.c_str(), 0) == 0;
 #else
     return ::access(filename.c_str(), F_OK) == 0;
 #endif
 }
 
-#ifdef _WIN32
+#if _WIN32
 // This routine maps Win32 OS error codes to readable text strngs.
 static std::string get_win32_message(DWORD error_code)
 {
@@ -2158,7 +2158,6 @@ remove_folder_and_subfolders(const std::string& folder)
     int ret = SHFileOperation(&fo);
     if (ret == 0 && !fo.fAnyOperationsAborted)
         return true;
-#endif
     return false;
 #endif
 #else
@@ -2529,7 +2528,7 @@ locate_zone(const std::string& tz_name)
 }
 
 #ifdef TZ_TEST
-#ifdef _WIN32
+#if _WIN32
 const time_zone*
 locate_native_zone(const std::string& native_tz_name)
 {
@@ -2633,7 +2632,7 @@ operator<<(std::ostream& os, const local_info& r)
     return os;
 }
 
-#ifdef _WIN32
+#if _WIN32
 
 const time_zone*
 current_zone()

--- a/tz.h
+++ b/tz.h
@@ -59,11 +59,7 @@ Technically any OS may use the mapping process but currently only Windows does u
 #endif
 
 #ifndef HAS_REMOTE_API
-#  ifndef _MSC_VER
 #    define HAS_REMOTE_API 1
-#  else
-#    define HAS_REMOTE_API 0
-#  endif
 #endif
 
 #ifndef AUTO_DOWNLOAD

--- a/tz.h
+++ b/tz.h
@@ -48,7 +48,7 @@ On Windows, the names are never "Standard" so mapping is always required.
 Technically any OS may use the mapping process but currently only Windows does use it.
 */
 
-#ifdef _WIN32
+#if _WIN32
 #ifndef TIMEZONE_MAPPING
 #define TIMEZONE_MAPPING 1
 #endif
@@ -730,8 +730,8 @@ bool        remote_install(const std::string& version);
 #endif
 
 const time_zone* locate_zone(const std::string& tz_name);
-#ifdef TZ_TEST
-#ifdef _WIN32
+#if TZ_TEST
+#if _WIN32
 const time_zone* locate_native_zone(const std::string& native_tz_name);
 #endif
 #endif


### PR DESCRIPTION
…and AUTO_DOWNLOAD.

This patch enables the automatic tz update feature of TZ on windows. This patch (for now) also makes these changes for Windows:
* The tzdata folder is moved from c:\tzdata to the users's download directory. typically \users\username\Downloads\tzdata.
* A tz app will attempt to download temporary files into the Downloads folder and unpack them into downloads\tzdata subfolder.
This matches the model on other platforms.
* Also, the WindowsTimezones.CSV is no longer used, it is downlaod as an .XML file ans used directly.
* Non automatic update users of tz will need to fetch this file and install it manually.

Later patches in the next day or so may possibly change this behaviour and/or install to a dedicated tzdata folder in the users home directory other than the Downloads one. TBD.

This patch takes a dependency on the tinyxml2 library though this may change soon, TBD. But until then github for those files for now.
Documentation will be updated in later patches with more info on this and how to build things.

As a temporary hint now, validate.cpp from the TZ tz_test folder can be built to test the auto update feature on Windows, like so:

cl /Zi /MDd /EHsc /DCURL_STATICLIB /DTIMEZONE_MAPPING=1 /DAUTO_DOWNLOAD=1 validate.cpp ..\..\tz.cpp ..\..\..\tinyxml2\tinyxml2.cpp -I..\.. -I..\..\..\ -I\projects\curl\include -I\projects\tinyxml libcurld.lib advapi32.lib WSock32.lib WLDap32.lib ws2_32.lib shell32.lib ole32.lib -link /LIBPATH:c:\projects\curl\lib

This command builds in debug mode. For release mode, use libcurl (with no d) and drop the /Zi switch and use /MD instead of /MDd.
More info on this in later patches.