### PR TITLE
HAS_REMOTE_API support for Windows. Adds support for MingW too.

### DIFF
--- a/date.h
+++ b/date.h
@@ -50,17 +50,20 @@ namespace date
 // MSVC's constexpr support is still a WIP, even in VS2015.
 // Fall back to a lesser mode to support it.
 // TODO: Remove this or retest later once MSVC's constexpr improves.
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && ! defined(__clang__)
+// MS cl compiler.
 #  define CONSTDATA const
 #  define CONSTCD11
 #  define CONSTCD14
 #  define NOEXCEPT _NOEXCEPT
 #elif __cplusplus >= 201402
+// C++14
 #  define CONSTDATA constexpr
 #  define CONSTCD11 constexpr
 #  define CONSTCD14 constexpr
 #  define NOEXCEPT noexcept
 #else
+// C++11
 #  define CONSTDATA constexpr
 #  define CONSTCD11 constexpr
 #  define CONSTCD14
@@ -3826,14 +3829,15 @@ class time_of_day
 {
     using base = detail::time_of_day_storage<Duration>;
 public:
-#ifndef _MSC_VER
-    using base::base;
-#else
+// MS cl compiler.
+#if _MSC_VER && ! defined(__clang__)
     template <class ...Args>
     explicit time_of_day(Args&& ...args)
         : base(std::forward<Args>(args)...)
         {}
-#endif // _MSC_VER
+#else
+    using base::base;
+#endif
 };
 
 template <class Rep, class Period,

--- a/tz.cpp
+++ b/tz.cpp
@@ -195,6 +195,7 @@ get_known_folder(const GUID& folderid)
     return folder;
 }
 
+// Usually something like "c:\Program Files".
 static
 std::string
 get_program_folder()
@@ -202,6 +203,7 @@ get_program_folder()
     return get_known_folder(FOLDERID_ProgramFiles);
 }
 
+// Usually something like "c:\Users\username\Downloads".
 static
 std::string
 get_download_folder()
@@ -2336,7 +2338,8 @@ extract_gz_file(const std::string& version,
     if (run_program(cmd) == EXIT_SUCCESS)
         unzip_result = true;
 #endif
-    delete_file(gz_file);
+    if (unzip_result)
+        delete_file(gz_file);
 
     // Use the unzip program extract the data from the tar file that was
     // just extracted from the archive.
@@ -2356,7 +2359,9 @@ extract_gz_file(const std::string& version,
         unzip_result = true;
 #endif
 
-    delete_file(tar_file);
+    if (unzip_result)
+        delete_file(tar_file);
+
     return unzip_result;
 
 #else //! _WIN32

--- a/tz.cpp
+++ b/tz.cpp
@@ -422,7 +422,7 @@ void
 sort_zone_mappings(std::vector<date::detail::timezone_mapping>& mappings)
 {
     std::sort(mappings.begin(), mappings.end(),
-        [](const auto& lhs, const auto& rhs)->bool
+        [](const date::detail::timezone_mapping& lhs, const date::detail::timezone_mapping& rhs)->bool
     {
         auto other_result = lhs.other.compare(rhs.other);
         if (other_result < 0)

--- a/tz.cpp
+++ b/tz.cpp
@@ -25,6 +25,53 @@
 // been invented (that woud involve another several millennia of evolution).
 // We did not mean to shout.
 
+#if _WIN32
+// Windows.h will be included directly and indirectly (e.g. by curl).
+// We need to define these macros to prevent Windows.h bringing in
+// more than we need and do it eearly so Windows.h doesn't get included
+// without these macros having been defined.
+// min/max macrosinterfere with the C++ versions.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+// We don't need all that Windows has to offer.
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+// None of this happens with the MS SDK (at least VS14 which I tested), but:
+// Compiling with mingw, we get "error: 'KF_FLAG_DEFAULT' was not declared in this scope."
+// and error: 'SHGetKnownFolderPath' was not declared in this scope.".
+// It seems when using mingw NTDDI_VERSION is undefined and that
+// causes KNOWN_FOLDER_FLAG and the KF_ flags to not get defined.
+// So we must define NTDDI_VERSION to get those flags on mingw.
+// The docs say though here:
+// https://msdn.microsoft.com/en-nz/library/windows/desktop/aa383745(v=vs.85).aspx
+// that "If you define NTDDI_VERSION, you must also define _WIN32_WINNT."
+// So we declare we require Vista or greater.
+#if __MINGW32__
+
+#ifndef NTDDI_VERSION
+#define NTDDI_VERSION 0x06000000
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#elif NTDDI_VERSION < 0x06000000
+#warning "If this fails to compile NTDDI_VERSION may be to low. See comments above."
+#endif
+// But once we define the values above we then get this linker error:
+// "tz.cpp:(.rdata$.refptr.FOLDERID_Downloads[.refptr.FOLDERID_Downloads]+0x0): undefined reference to `FOLDERID_Downloads'"
+// which #include <initguid.h> cures see:
+// https://support.microsoft.com/en-us/kb/130869
+#include <initguid.h>
+// But with <initguid.h> included, the error moves on to:
+// error: 'FOLDERID_Downloads' was not declared in this scope
+// Which #include <knownfolders.h> cures.
+#include <knownfolders.h>
+
+#endif // __MINGW32__
+
+#include <Windows.h>
+#endif // _WIN32
+
 #include "tz_private.h"
 
 #include <algorithm>
@@ -39,121 +86,71 @@
 #include <tuple>
 #include <vector>
 #include <sys/stat.h>
-#if HAS_REMOTE_API
-#include <curl/curl.h>
-#endif
-#ifdef _WIN32
+
+#if _WIN32
 #include <locale>
 #include <codecvt>
-#endif
-
-#if TIMEZONE_MAPPING
-// Timezone mapping maps native (e.g. Windows) timezone names to the "Standard" names
-// used by this library.
-// The mapping process parses a CSV file of mapping data where each line is of the format:
-// "other","territory","type"<newline>
-// e.g. "GMT Standard Time", "001", "Europe/London"
-// and <newline>
-// Windows typically uses CRLF, Linux/Unix/Mac OS use LF, and old Mac's use CR.
-// On Linux/Mac, no mapping file is required as that is the native format already.
-// C++11 should work but C++14 is preferred even there too
-// because the date library in general works better with C++14.
-#include <iomanip>
-#endif
+#endif // _WIN32
 
 // unistd.h is used on some platforms as part of the the means to get
 // the current time zone. On Win32 Windows.h provides a means to do it.
 // gcc/mingw supports unistd.h on Win32 but MSVC does not.
 
-#ifdef _WIN32
-// Prevent windows defining min/max macros that will interfere with C++ versions.
-#ifndef NOMINMAX
-#define NOMINMAX
+#if _WIN32
+#include <io.h> // _unlink etc.
+#include <ShlObj.h> // CoTaskFree, ShGetKnownFolderPath etc.
+#if HAS_REMOTE_API
+#include <direct.h> // _mkdir
+#include <Shellapi.h> // ShFileOperation etc.
 #endif
-// We don't need everything Windows.h has to offer.
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <Windows.h>
-#include <io.h>
-#else
+#else // !WIN32
 #include <unistd.h>
 #include <wordexp.h>
 #endif
 
-namespace date
-{
-// +---------------------+
-// | Begin Configuration |
-// +---------------------+
-
-#if _WIN32 // TODO: sensible default for all platforms.
-static const std::string install{ "c:\\tzdata" };
-#else  // !_WIN32
-
-static
-std::string
-expand_path(std::string path)
-{
-    ::wordexp_t w{};
-    ::wordexp(path.c_str(), &w, 0);
-    assert(w.we_wordc == 1);
-    path = w.we_wordv[0];
-    ::wordfree(&w);
-    return path;
-}
-
-static const std::string install = expand_path("~/Downloads/tzdata");
-
-#endif  // !_WIN32
-
-static const std::vector<std::string> files =
-{
-    "africa", "antarctica", "asia", "australasia", "backward", "etcetera", "europe",
-    "pacificnew", "northamerica", "southamerica", "systemv", "leapseconds"
-};
-
-// These can be used to reduce the range of the database to save memory
-CONSTDATA auto min_year = date::year::min();
-CONSTDATA auto max_year = date::year::max();
-
-CONSTDATA auto min_day = date::jan/1;
-CONSTDATA auto max_day = date::dec/31;
-
-// +-------------------+
-// | End Configuration |
-// +-------------------+
-
-namespace detail
-{
-struct undocumented {explicit undocumented() = default;};
-}
-
-#ifndef _MSC_VER
-static_assert(min_year <= max_year, "Configuration error");
+#if HAS_REMOTE_API
+// Note curl includes windows.h so we must include curl AFTER definitions of things
+// that effect windows.h such as NOMINMAX.
+#include <curl/curl.h>
 #endif
+
+#if TIMEZONE_MAPPING
+// See comments in tz.h regarding the XML mapping file.
+#include "tinyxml2.h"
+#endif
+
 
 // Until filesystem arrives.
-static CONSTDATA char folder_delimiter =
-#ifdef _WIN32
-'\\';
+#if _WIN32
+static CONSTDATA char folder_delimiter = '\\';
 #else
-'/';
+static CONSTDATA char folder_delimiter = '/';
 #endif
 
-static bool file_exists(const std::string& filename)
+namespace
 {
-#ifdef _WIN32
-    return ::_access(filename.c_str(), 0) == 0;
-#else
-    return ::access(filename.c_str(), F_OK) == 0;
+#if HAS_REMOTE_API
+    enum class download_file_options { binary, text };
+#endif
+#if _WIN32
+    struct task_mem_deleter
+    {
+        void operator()(wchar_t buf[])
+        {
+            if (buf != nullptr)
+                CoTaskMemFree(buf);
+        }
+    };
+    using co_task_mem_ptr = std::unique_ptr<wchar_t[], task_mem_deleter>;
 #endif
 }
 
-#ifdef _WIN32
-// Win32 support requires calling OS functions.
-// This routine maps OS error codes to readable text strngs.
-static std::string get_win32_message(DWORD error_code)
+#if _WIN32
+
+// This routine maps Win32 OS error codes to readable text strngs.
+static
+std::string
+get_win32_message(DWORD error_code)
 {
     struct free_message {
         void operator()(char buf[]) {
@@ -180,7 +177,128 @@ static std::string get_win32_message(DWORD error_code)
     assert(message_buffer.get() != nullptr);
     return std::string(message_buffer.get());
 }
-#endif  // _WIN32
+
+// We might need to know certain locations even if not using the remote API,
+// so keep these routines out of that block for now.
+static
+std::string
+get_known_folder(const GUID& folderid)
+{
+    std::string folder;
+    PWSTR pfolder = nullptr;
+    HRESULT hr = SHGetKnownFolderPath(folderid, KF_FLAG_DEFAULT, NULL, &pfolder);
+    if (SUCCEEDED(hr))
+    {
+        co_task_mem_ptr folder_ptr(pfolder);
+        folder = std::string(folder_ptr.get(), folder_ptr.get() + wcslen(folder_ptr.get()));
+    }
+    return folder;
+}
+
+static
+std::string
+get_program_folder()
+{
+    return get_known_folder(FOLDERID_ProgramFiles);
+}
+
+static
+std::string
+get_download_folder()
+{
+    return get_known_folder(FOLDERID_Downloads);
+}
+
+#else // !_WIN32
+static
+std::string
+expand_path(std::string path)
+{
+    ::wordexp_t w{};
+    ::wordexp(path.c_str(), &w, 0);
+    assert(w.we_wordc == 1);
+    path = w.we_wordv[0];
+    ::wordfree(&w);
+    return path;
+}
+#endif  // !_WIN32
+
+static
+bool
+file_exists(const std::string& filename)
+{
+#if _WIN32
+    return ::_access(filename.c_str(), 0) == 0;
+#else
+    return ::access(filename.c_str(), F_OK) == 0;
+#endif
+}
+
+namespace date
+{
+// +---------------------+
+// | Begin Configuration |
+// +---------------------+
+
+static std::string get_install()
+{
+#if _WIN32
+    std::string install = get_download_folder();
+    install += folder_delimiter;
+    install += "tzdata";
+#else
+    std::string install = expand_path("~/Downloads/tzdata");
+#endif
+    return install;
+}
+
+static const std::string install = get_install();
+
+static
+std::string
+get_download_gz_file(const std::string& version)
+{
+    auto file = install + version + ".tar.gz";
+    return file;
+}
+
+static
+std::string
+get_download_tar_file(const std::string& version)
+{
+    auto file = install;
+    file += folder_delimiter;
+    file += "tzdata";
+    file += version;
+    file += ".tar";
+    return file;
+}
+
+static const std::vector<std::string> files =
+{
+    "africa", "antarctica", "asia", "australasia", "backward", "etcetera", "europe",
+    "pacificnew", "northamerica", "southamerica", "systemv", "leapseconds"
+};
+
+// These can be used to reduce the range of the database to save memory
+CONSTDATA auto min_year = date::year::min();
+CONSTDATA auto max_year = date::year::max();
+
+CONSTDATA auto min_day = date::jan/1;
+CONSTDATA auto max_day = date::dec/31;
+
+// +-------------------+
+// | End Configuration |
+// +-------------------+
+
+namespace detail
+{
+struct undocumented {explicit undocumented() = default;};
+}
+
+#ifndef _MSC_VER
+static_assert(min_year <= max_year, "Configuration error");
+#endif
 
 #if TIMEZONE_MAPPING
 
@@ -229,12 +347,8 @@ namespace // Put types in an anonymous name space.
             return ERROR_SUCCESS;
         }
 
-        // WARNING: this function has a hard-coded value size limit.
-        // It is not a general-purpose function.
-        // It should be sufficient for our use cases.
-        // The function could be made workable for any size string
-        // but we don't need the complexity of implementing that
-        // for our meagre purposes right now.
+        // WARNING: this function is not a general-purpose function.
+        // It has a hard-coded value size limit that should be sufficient for our use cases.
         bool get_string(const wchar_t* key_name, std::string& value)
         {
             value.clear();
@@ -272,12 +386,70 @@ namespace // Put types in an anonymous name space.
     };
 } // anonymous namespace
 
+static
+std::string
+get_download_mapping_file(const std::string& version)
+{
+    auto file = install + version + "windowsZones.xml";
+    return file;
+}
+
+static
+std::vector<date::detail::timezone_mapping>
+load_zone_mappings_from_xml_file(const std::string& input_path)
+{
+    using tinyxml2::XMLDocument;
+    std::vector<date::detail::timezone_mapping> zone_map_list;
+    XMLDocument doc;
+    doc.LoadFile(input_path.c_str());
+    auto supplementalData = doc.FirstChildElement("supplementalData");
+    auto windowsZones = supplementalData->FirstChildElement("windowsZones");
+    auto mapTimeZones = windowsZones->FirstChildElement("mapTimezones");
+
+    for (auto mapZone = mapTimeZones->FirstChildElement("mapZone");
+        mapZone != nullptr; mapZone = mapZone->NextSiblingElement())
+    {
+        auto other = mapZone->Attribute("other");
+        auto territory = mapZone->Attribute("territory");
+        auto type = mapZone->Attribute("type");
+        zone_map_list.emplace_back(other, territory, type);
+    }
+    return zone_map_list;
+}
+
+static
+void
+sort_zone_mappings(std::vector<date::detail::timezone_mapping>& mappings)
+{
+    std::sort(mappings.begin(), mappings.end(),
+        [](const auto& lhs, const auto& rhs)->bool
+    {
+        auto other_result = lhs.other.compare(rhs.other);
+        if (other_result < 0)
+            return true;
+        else if (other_result == 0)
+        {
+            auto territory_result = lhs.territory.compare(rhs.territory);
+            if (territory_result < 0)
+                return true;
+            else if (territory_result == 9)
+            {
+                if (lhs.type < rhs.type)
+                    return true;
+            }
+        }
+        return false;
+    });
+}
+
 // This function returns an exhaustive list of time zone information
 // from the Windows registry.
 // The routine tries to load as many time zone entries as possible despite errors.
 // We don't want to fail to load the whole database just because one record can't be read.
 
-static void get_windows_timezone_info(std::vector<detail::timezone_info>& tz_list)
+static
+void
+get_windows_timezone_info(std::vector<detail::timezone_info>& tz_list)
 {
     tz_list.clear();
     LONG result;
@@ -353,7 +525,9 @@ static void get_windows_timezone_info(std::vector<detail::timezone_info>& tz_lis
 // under the windows registry key Time Zones.
 // To be clear, standard_name does NOT represent a windows timezone id
 // or an IANA tzid
-static const detail::timezone_info* find_native_timezone_by_standard_name(
+static
+const detail::timezone_info*
+find_native_timezone_by_standard_name(
     const std::string& standard_name)
 {
     // TODO! we can improve on linear search.
@@ -367,119 +541,8 @@ static const detail::timezone_info* find_native_timezone_by_standard_name(
     return nullptr;
 }
 
-// Read CSV file of "other","territory","type".
-// See timezone_mapping structure for more info.
-// This function should be kept in sync with the code that writes this file.
-static std::vector<detail::timezone_mapping>
-load_timezone_mappings_from_csv_file(const std::string& input_path)
-{
-    size_t line = 0;
-    std::vector<detail::timezone_mapping> mappings;
-    std::ifstream is(input_path,
-#if _WIN32
-        std::ios_base::in // open in text mode on Win32, so getline will eat '\n' and '\r\n'
-#else
-        std::ios_base::in | std::ios_base::binary
-#endif
-    );
-    if (!is.is_open())
-    {
-        // We don't emit file exceptions because that's an implementation detail.
-        std::string msg = "Error opening time zone mapping file \"";
-        msg += input_path;
-        msg += "\".";
-        throw std::runtime_error(msg);
-    }
-
-    std::istringstream sis;
-    auto error = [&](const char* info)
-    {
-        std::string msg = "Error reading zone mapping file \"";
-        msg += input_path;
-        msg += "\" at line ";
-        msg += std::to_string(line);
-        msg += ": ";
-        msg += info;
-        throw std::runtime_error(msg);
-    };
-    auto read_field_quote = [&]()
-    {
-        char field_delim;
-        sis.read(&field_delim, 1);
-        auto read_count = sis.gcount();
-        if (sis.gcount() != 1 || field_delim != '"')
-            error("field '\"' expected.");        
-    };
-    auto read_field_delim = [&]()
-    {
-        char field_delim;
-        sis.read(&field_delim, 1);
-        if (sis.gcount() != 1 || field_delim != ',')
-            error("delimiter ',' expected.");
-    };
-    std::string copyright;
-    bool blank = false;
-    for (;;)
-    {
-        std::getline(is, copyright);
-        ++line; // Make sure our line number is in sync with however many copyright lines we have.
-        if (is.eof())
-            break;
-        if (copyright.empty())
-        {
-            --line;
-            blank = true;
-            break;
-        }
-    }
-    const int min_copyright_lines = 3;
-    if (!blank || line < min_copyright_lines)
-    {
-        std::string msg = "Expected at least ";
-        msg += std::to_string(min_copyright_lines);
-        msg += " lines of copyright notice followed by a blank line.";
-        error(msg.c_str());
-    }
-    ++line;
-
-    std::string linebuf;
-    for (;;)
-    {
-        detail::timezone_mapping zm{};
-        std::getline(is, linebuf);
-        // Stop on error or first blank line.
-        // linebuf.size() is the length read but it excludes the length of any line delimiter actually read (e.g. LF/CRLF).
-        // If linebuf.size() is 0 it *might* not mean nothing was read (error) or eof, it could just
-        // indicate only a line delimiter was read. Use is.eof() to distinquish end of file from a blank line.
-        if (linebuf.empty()) // on eof linebuf will be empty.
-        {
-            if (is.eof())
-                break;
-            error("Formatting error. Blank lines not allowed.");
-        }
-        sis.clear();
-        sis.str(linebuf);
-
-        read_field_quote();
-        std::getline(sis, zm.other, '\"');
-        read_field_delim();
-
-        read_field_quote();
-        std::getline(sis, zm.territory, '\"');
-        read_field_delim();
-
-        read_field_quote();
-        std::getline(sis, zm.type, '\"');
-        if ((size_t)sis.tellg() != linebuf.length()) // Excess characters? We should have processed all in the line buffer.
-            error("Formatting error.");
-        ++line;
-        mappings.push_back(std::move(zm));
-    }
-    is.close();
-    return mappings;
-}
-
-static bool
+static
+bool
 native_to_standard_timezone_name(const std::string& native_tz_name,
                                  std::string& standard_tz_name)
 {
@@ -2007,38 +2070,74 @@ curl_init()
     return std::unique_ptr<CURL, decltype(curl_delete)>{::curl_easy_init(), curl_delete};
 }
 
+static
+bool
+download_to_string(const std::string& url, std::string& str)
+{
+    str.clear();
+    auto curl = curl_init();
+    if (!curl)
+        return false;
+    std::string version;
+    curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
+    curl_write_callback write_cb = [](char* contents, std::size_t size, std::size_t nmemb, void* userp)
+        -> std::size_t
+    {
+        auto& str = *static_cast<std::string*>(userp);
+        auto realsize = size * nmemb;
+        str.append(contents, realsize);
+        return realsize;
+    };
+    curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &str);
+    auto res = curl_easy_perform(curl.get());
+    return (res == CURLE_OK);
+}
+
+static
+bool
+download_to_file(const std::string& url, const std::string& local_filename, download_file_options opts)
+{
+    auto curl = curl_init();
+    if (!curl)
+        return false;
+    curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
+    curl_write_callback write_cb = [](char* contents, std::size_t size, std::size_t nmemb, void* userp)
+        -> std::size_t
+    {
+        auto& of = *static_cast<std::ofstream*>(userp);
+        auto realsize = size * nmemb;
+        // TODO! We probably should signal write failures here via the return value, but we don't know
+        // how much data was actually written to do that. Throwing is dubious as it might affect
+        // curl as it's C based. In any case other parts of the process like tar unpacking are more
+        // likely disk affected than here and they aren't caught either yet so worry about here later.
+        of.write(contents, realsize);
+        return realsize;
+    };
+    curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, write_cb);
+    decltype(curl_easy_perform(curl.get())) res;
+    {
+        std::ofstream of(local_filename,
+            opts == download_file_options::binary ? std::ofstream::out | std::ofstream::binary : std::ofstream::out);
+        curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &of);
+        res = curl_easy_perform(curl.get());
+    }
+    return res == CURLE_OK;
+}
+
 std::string
 remote_version()
 {
     std::string version;
-    auto curl = curl_init();
-    if (curl != nullptr)
+    std::string str;
+    if (download_to_string("http://www.iana.org/time-zones", str))
     {
-        curl_easy_setopt(curl.get(), CURLOPT_URL, "http://www.iana.org/time-zones");
-        using curl_callback = std::size_t(*)(void* contents, std::size_t size,
-                                             std::size_t nmemb, void* userp);
-        curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION,
-            static_cast<curl_callback>(
-            [](void* contents, std::size_t size, std::size_t nmemb, void* userp)
-                -> std::size_t
-            {
-                auto& str = *static_cast<std::string*>(userp);
-                auto realsize = size * nmemb;
-                auto data = static_cast<const char*>(contents);
-                str.append(data, realsize);
-                return realsize;
-            }));
-        std::string str;
-        curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &str);
-        auto res = curl_easy_perform(curl.get());
-        if (res == CURLE_OK)
-        {
-            CONSTDATA char db[] = "/time-zones/repository/releases/tzdata";
-            CONSTDATA auto db_size = sizeof(db) - 1;
-            auto p = str.find(db, 0, db_size);
-            if (p != std::string::npos && p + (db_size + 5) <= str.size())
-                version = str.substr(p + db_size, 5);
-        }
+        CONSTDATA char db[] = "/time-zones/repository/releases/tzdata";
+        CONSTDATA auto db_size = sizeof(db) - 1;
+        auto p = str.find(db, 0, db_size);
+        const int ver_str_len = 5;
+        if (p != std::string::npos && p + (db_size + ver_str_len) <= str.size())
+            version = str.substr(p + db_size, ver_str_len);
     }
     return version;
 }
@@ -2047,35 +2146,225 @@ bool
 remote_download(const std::string& version)
 {
     assert(!version.empty());
-    auto curl = curl_init();
-    if (curl != nullptr)
+    auto url = "http://www.iana.org/time-zones/repository/releases/tzdata" + version + ".tar.gz";
+    bool result = download_to_file(url, get_download_gz_file(version), download_file_options::binary);
+#if TIMEZONE_MAPPING
+    if (result)
     {
-        auto url = "http://www.iana.org/time-zones/repository/releases/tzdata" +
-                   version + ".tar.gz";
-        curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
-        using curl_callback = std::size_t(*)(void* contents, std::size_t size,
-                                             std::size_t nmemb, void* userp);
-        curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION,
-            static_cast<curl_callback>(
-            [](void* contents, std::size_t size, std::size_t nmemb, void* userp)
-                -> std::size_t
-            {
-                auto& of = *static_cast<std::ofstream*>(userp);
-                auto realsize = size * nmemb;
-                auto data = static_cast<const char*>(contents);
-                of.write(data, realsize);
-                return realsize;
-            }));
-        auto tarfile = install + version + ".tar.gz";
-        decltype(curl_easy_perform(curl.get())) res;
-        {
-            std::ofstream of(tarfile);
-            curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &of);
-            res = curl_easy_perform(curl.get());
-        }
-        return res == CURLE_OK;
+        auto mapping_file = get_download_mapping_file(version);
+        result = download_to_file("http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml",
+            mapping_file, download_file_options::text);
+    }
+#endif
+    return result;
+}
+
+// TODO! Using system() create a process and a console window.
+// This is useful to see what errors may occur but is slow and distracting.
+// Consider implementing this functionality more directly, such as
+// using _mkdir and CreateProcess etc.
+// But use the current means now as matches Unix implementations and while
+// in proof of concept / testing phase.
+
+static
+bool
+remove_folder_and_subfolders(const std::string& folder)
+{
+#if _WIN32
+#if USE_SHELL_API
+    // Delete the folder contents by deleting the folder.
+    std::string cmd = "rd /s /q \"";
+    cmd += folder;
+    cmd += '\"';
+    return std::system(cmd.c_str()) == EXIT_SUCCESS;
+#else
+    // Create a buffer containing the path to delete. It must be terminated
+    // by two nulls. Who designs these API's...
+    std::vector<char> from;
+    from.assign(folder.begin(), folder.end());
+    from.push_back('\0');
+    from.push_back('\0');
+    SHFILEOPSTRUCT fo{}; // Zero initialize.
+    fo.wFunc = FO_DELETE;
+    fo.pFrom = from.data();
+    fo.fFlags = FOF_NO_UI;
+    int ret = SHFileOperation(&fo);
+    if (ret == 0 && !fo.fAnyOperationsAborted)
+        return true;
+    return false;
+#endif
+#else // !WIN32
+    return std::system(("rm -R " + folder).c_str()) == EXIT_SUCCESS;
+#endif
+}
+
+static
+bool
+make_directory(const std::string& folder)
+{
+#if _WIN32
+#if USE_SHELL_API
+    // Re-create the folder.
+    std::string cmd = "mkdir \"";
+    cmd += folder;
+    cmd += '\"';
+    return std::system(cmd.c_str()) == EXIT_SUCCESS;
+#else
+    return _mkdir(folder.c_str()) == 0;
+#endif
+#else // !WIN32
+    return std::system(("mkdir " + folder).c_str()) == EXIT_SUCCESS;
+#endif
+}
+
+static
+bool
+delete_file(const std::string& file)
+{
+#if _WIN32
+#if USE_SHELL_API
+    std::string cmd = "del \"";
+    cmd += file;
+    cmd += '\"';
+    return std::system(cmd.c_str()) == 0;
+#else
+    return _unlink(file.c_str()) == 0;
+#endif
+#else // !WIN32
+    return std::system(("rm " + file).c_str()) == EXIT_SUCCESS;
+#endif
+}
+
+static
+bool
+move_file(const std::string& from, const std::string& to)
+{
+#if _WIN32
+#if USE_SHELL_API
+    std::string cmd = "move \"";
+    cmd += from;
+    cmd += "\" \"";
+    cmd += to;
+    cmd += '\"';
+    return std::system(cmd.c_str()) == EXIT_SUCCESS;
+#else
+    return !!::MoveFile(from.c_str(), to.c_str());
+#endif
+#else // !WIN32
+    return std::system(("mv " + from + " " + to).c_str()) == EXIT_SUCCESS;
+#endif
+}
+
+#if _WIN32
+// Note folder can and usually does contain spaces.
+// Note assume's 7 zip is in the default installation location.
+// TODO! consider more certain means of finding it such as looking in the registry.
+static
+std::string
+get_unzip_program()
+{
+    std::string path;
+    path += get_program_folder();
+    path += folder_delimiter;
+    path += "7-Zip\\7z.exe";
+    return path;
+}
+
+static
+int
+run_program(const std::string& command)
+{
+    STARTUPINFO si{};
+    si.cb = sizeof(si);
+    PROCESS_INFORMATION pi{};
+
+    // Allegedly CreateProcess overwrites the command line. Ugh.
+    std::string mutable_command(command);
+    if (CreateProcess(nullptr, &mutable_command[0],
+        nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
+    {
+        WaitForSingleObject(pi.hProcess, INFINITE);
+        DWORD exit_code;
+        bool got_exit_code = !!GetExitCodeProcess(pi.hProcess, &exit_code);
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        // Not 100% sure about this still active thing is correct,
+        // but I'm going with it because I *think* WaitForSingleObject might
+        // return in some cases without INFINITE-ly waiting.
+        // But why/wouldn't GetExitCodeProcess return false in that case?
+        if (got_exit_code && exit_code != STILL_ACTIVE)
+            return static_cast<int>(exit_code);
+    }
+    return EXIT_FAILURE;
+}
+#endif // _WIN32
+
+static
+bool
+extract_gz_file(const std::string& version,
+                const std::string& gz_file, const std::string& dest_folder)
+{
+    auto tar_file = get_download_tar_file(version);
+
+#if _WIN32
+    auto unzip_prog = get_unzip_program();
+    bool unzip_result = false;
+    // Use the unzip program to extract the tar file from the archive.
+    
+    // Aim to create a string like:
+    // "C:\Program Files\7-Zip\7z.exe" x "C:\Users\SomeUser\Downloads\tzdata2016d.tar.gz" -o"C:\Users\SomeUser\Downloads\tzdata"
+    std::string cmd;
+    cmd = '\"';
+    cmd += unzip_prog;
+    cmd += "\" x \"";
+    cmd += gz_file;
+    cmd += "\" -o\"";
+    cmd += dest_folder;
+    cmd += '\"';
+
+#if USE_SHELL_API
+    // When using shelling out with std::system() extra quotes are required around the whole command.
+    // It's weird but neccessary it seems, see:
+    // http://stackoverflow.com/questions/27975969/how-to-run-an-executable-with-spaces-using-stdsystem-on-windows
+
+    cmd = "\"" + cmd + "\"";
+    if (std::system(cmd.c_str()) == EXIT_SUCCESS)
+        unzip_result = true;
+#else
+    if (run_program(cmd) == EXIT_SUCCESS)
+        unzip_result = true;
+#endif
+    delete_file(gz_file);
+
+    // Use the unzip program extract the data from the tar file that was
+    // just extracted from the archive.
+    cmd = '\"';
+    cmd += unzip_prog;
+    cmd += "\" x \"";
+    cmd += tar_file;
+    cmd += "\" -o\"";
+    cmd += install;
+    cmd += '\"';
+#if USE_SHELL_API
+    cmd = "\"" + cmd + "\"";
+    if (std::system(cmd.c_str()) == EXIT_SUCCESS)
+        unzip_result = true;
+#else
+    if (run_program(cmd) == EXIT_SUCCESS)
+        unzip_result = true;
+#endif
+
+    delete_file(tar_file);
+    return unzip_result;
+
+#else //! _WIN32
+    if (std::system(("tar -xzf " + gz_file + " -C " + install).c_str()) == EXIT_SUCCESS)
+    {        
+        if (std::system(("rm " + gz_file).c_str()) == EXIT_SUCCESS)
+            return true;
     }
     return false;
+#endif
 }
 
 bool
@@ -2083,19 +2372,28 @@ remote_install(const std::string& version)
 {
     auto success = false;
     assert(!version.empty());
-    auto tarfile = install + version + ".tar.gz";
-    if (file_exists(tarfile))
+
+    auto gz_file = get_download_gz_file(version);
+    if (file_exists(gz_file))
     {
         if (file_exists(install))
-            std::system(("rm -R " + install).c_str());
-        if (std::system(("mkdir " + install + " && "
-                 "tar -xzf " + tarfile + " -C " + install).c_str()) == 0)
-            success = true;
-        std::system(("rm " + tarfile).c_str());
+            remove_folder_and_subfolders(install);
+        if (make_directory(install))
+        {
+            if (extract_gz_file(version, gz_file, install))
+                success = true;
+        }
+#if TIMEZONE_MAPPING
+        auto mapping_file_source = get_download_mapping_file(version);
+        auto mapping_file_dest = install;
+        mapping_file_dest += folder_delimiter;
+        mapping_file_dest += "windowsZones.xml";
+        if (!move_file(mapping_file_source, mapping_file_dest))
+            success = false;
+#endif
     }
     return success;
 }
-
 #endif  // HAS_REMOTE_API
 
 static
@@ -2131,7 +2429,17 @@ init_tzdb()
     {
         auto rv = remote_version();
         if (!rv.empty() && remote_download(rv))
-            remote_install(rv);
+        {
+            if (!remote_install(rv))
+            {
+                std::string msg = "Timezone database version \"";
+                msg += rv;
+                msg += "\" did not install correctly to \"";
+                msg += install;
+                msg += "\"";
+                throw std::runtime_error(msg);
+            }
+        }
         if (!file_exists(install))
         {
             std::string msg = "Timezone database not found at \"";
@@ -2221,10 +2529,11 @@ init_tzdb()
     db.leaps.shrink_to_fit();
 
 #if TIMEZONE_MAPPING
-    std::string mapping_file = path + "TimeZoneMappings.csv";
-    db.mappings = load_timezone_mappings_from_csv_file(mapping_file);
+    std::string mapping_file = path + "windowsZones.xml";
+    db.mappings = load_zone_mappings_from_xml_file(mapping_file);
+    sort_zone_mappings(db.mappings);
     get_windows_timezone_info(db.native_zones);
-#endif
+#endif // TIMEZONE_MAPPING
 
     return db;
 }
@@ -2286,8 +2595,7 @@ locate_zone(const std::string& tz_name)
     return &*zi;
 }
 
-#ifdef TZ_TEST
-#ifdef _WIN32
+#if TZ_TEST && TIMEZONE_MAPPING
 const time_zone*
 locate_native_zone(const std::string& native_tz_name)
 {
@@ -2295,14 +2603,13 @@ locate_native_zone(const std::string& native_tz_name)
     if (!native_to_standard_timezone_name(native_tz_name, standard_tz_name))
     {
         std::string msg;
-        msg = "locate_native_zone() failed: A mapping from the Windows Time Zone id \"";
+        msg = "locate_native_zone() failed: A mapping from the native/Windows Time Zone id \"";
         msg += native_tz_name;
         msg += "\" was not found in the time zone mapping database.";
         throw std::runtime_error(msg);
     }
     return locate_zone(standard_tz_name);
 }
-#endif
 #endif
 
 std::ostream&
@@ -2391,7 +2698,7 @@ operator<<(std::ostream& os, const local_info& r)
     return os;
 }
 
-#ifdef _WIN32
+#if _WIN32
 
 const time_zone*
 current_zone()
@@ -2427,7 +2734,14 @@ current_zone()
     }
     return date::locate_zone(standard_tzid);
 #else
-    // Currently Win32 requires mapping for this function to work.
+    // Currently Win32 requires iana <--> windows tz name mappings
+    // for this function to work.
+    // TODO! we should really support TIMEZONE_MAPPINGS=0 on Windows,
+    // And in this mode we should read the current iana timezone from a file.
+    // This would allow the TZ library do be used by apps that don't care
+    // about Windows standard names just iana names.
+    // This would allow the xml dependency to be dropped and none of
+    // the name mapping functions would be needed.
     throw std::runtime_error("current_zone not implemented.");
 #endif
 }

--- a/tz.h
+++ b/tz.h
@@ -48,9 +48,13 @@ On Windows, the names are never "Standard" so mapping is always required.
 Technically any OS may use the mapping process but currently only Windows does use it.
 */
 
-#ifdef _WIN32
+#if _WIN32
 #ifndef TIMEZONE_MAPPING
 #define TIMEZONE_MAPPING 1
+#endif
+#else
+#if TIMEZONE_MAPPING
+#error "Timezone mapping is not required or not implemented for this platform."
 #endif
 #endif
 
@@ -59,10 +63,10 @@ Technically any OS may use the mapping process but currently only Windows does u
 #endif
 
 #ifndef HAS_REMOTE_API
-#  ifndef _MSC_VER
-#    define HAS_REMOTE_API 1
-#  else
+#  if _WIN32
 #    define HAS_REMOTE_API 0
+#  else
+#    define HAS_REMOTE_API 1
 #  endif
 #endif
 
@@ -735,7 +739,7 @@ bool        remote_install(const std::string& version);
 
 const time_zone* locate_zone(const std::string& tz_name);
 #ifdef TZ_TEST
-#ifdef _WIN32
+#if _WIN32
 const time_zone* locate_native_zone(const std::string& native_tz_name);
 #endif
 #endif


### PR DESCRIPTION
Tested on Windows 7 and on Fedora 23 as well.

HAS_REMOTE_API requires Curl and 7-zip and to be installed in its default location.
Tinyxml2 is also required for Windows.

To test with Visual Studio, compile TZ's validate program in date\test\tz_test, using a command line like this:
cl /EHsc /DCURL_STATICLIB /DTIMEZONE_MAPPING=1 /DHAS_REMOTE_API=1 /DAUTO_DOWNLOAD=1 validate.cpp c:\projects\date\tz.cpp c:\projects\tinyxml2\tinyxml2.cpp  -Ic:\projects\date -Ic:\projects\tinyxml2 -Ic:\projects\curl\include -Ic:\projects\curl\build\include libcurl.lib advapi32.lib WSock32.lib WLDap32.lib ws2_32.lib shell32.lib ole32.lib -link /LIBPATH:c:\projects\curl\lib\debug

When HAS_REMOTE_API=0 only libraries advapi32.lib, ole32.lib and shell32.lib are required.
Note AUTO_DOWNLOAD should be 0 if HAS_REMOET_API is 0.