### PR TITLE
Prevent warnings when using -Wundef flag

### DIFF
--- a/date.h
+++ b/date.h
@@ -957,7 +957,7 @@ trunc(const std::chrono::duration<Rep, Period>& d)
 }
 
 // VS Update 2 provides floor, ceil, round, abs in chrono.
-#if _MSC_FULL_VER < 190023918
+#if !defined(_MSC_FULL_VER) || _MSC_FULL_VER < 190023918
 
 // round down
 template <class To, class Rep, class Period>
@@ -1054,14 +1054,14 @@ ceil(const std::chrono::time_point<Clock, FromDuration>& tp)
     return time_point<Clock, To>{ceil<To>(tp.time_since_epoch())};
 }
 
-#else  // _MSC_FULL_VER < 190023918
+#else  // !defined(_MSC_FULL_VER) || _MSC_FULL_VER < 190023918
 
 using std::chrono::floor;
 using std::chrono::ceil;
 using std::chrono::round;
 using std::chrono::abs;
 
-#endif  // _MSC_FULL_VER < 190023918
+#endif  // !defined(_MSC_FULL_VER) || _MSC_FULL_VER < 190023918
 
 // trunc towards zero
 template <class To, class Clock, class FromDuration>

--- a/date.h
+++ b/date.h
@@ -3829,7 +3829,7 @@ class time_of_day
 {
     using base = detail::time_of_day_storage<Duration>;
 public:
-#if !(_MSC_VER && !defined(__clang__))
+#if !(defined(_MSC_VER) && !defined(__clang__))
     // C++11
     using base::base;
 #else

--- a/tz.h
+++ b/tz.h
@@ -40,12 +40,12 @@
 // required. On Windows, the names are never "Standard" so mapping is always required.
 // Technically any OS may use the mapping process but currently only Windows does use it.
 
-#if _WIN32
+#ifdef _WIN32
 #  ifndef TIMEZONE_MAPPING
 #    define TIMEZONE_MAPPING 1
 #  endif
 #else
-#  if TIMEZONE_MAPPING
+#  ifdef TIMEZONE_MAPPING
 #    error "Timezone mapping is not required or not implemented for this platform."
 #  endif
 #endif
@@ -55,7 +55,7 @@
 #endif
 
 #ifndef HAS_REMOTE_API
-#  if _WIN32
+#  ifdef _WIN32
 #    define HAS_REMOTE_API 0
 #  else
 #    define HAS_REMOTE_API 1
@@ -625,7 +625,7 @@ operator>=(const sys_time<Duration>& x, const leap& y)
     return !(x < y);
 }
 
-#if TIMEZONE_MAPPING
+#ifdef TIMEZONE_MAPPING
 
 namespace detail
 {
@@ -677,7 +677,7 @@ struct TZ_DB
     std::vector<link>      links;
     std::vector<leap>      leaps;
     std::vector<Rule>      rules;
-#if TIMEZONE_MAPPING
+#ifdef TIMEZONE_MAPPING
     // TODO! These need some protection.
     std::vector<detail::timezone_mapping> mappings;
     std::vector<detail::timezone_info> native_zones;
@@ -1677,7 +1677,7 @@ parse(std::basic_istream<CharT, Traits>& is,
                 f.get(is, 0, is, err, &tm, b, e);
             if ((err & ios_base::failbit) == 0)
             {
-#if _WIN32
+#ifdef _WIN32
                 auto tt = _mkgmtime(&tm);
 #else
                 auto tt = timegm(&tm);


### PR DESCRIPTION
I had issues with clang 3.9 that does not define _MSC_FULL_VER on linux (at least by default).
As _MSC_FULL_VER is Microsoft-specific predefined macros, I think that it is reasonable to check
if it is defined first.
This fix forces all compilers that are not defining this macro to take the first path and that might not be the perfect solution.