### PR TITLE
Problem: date::format(..) doesn't compile

### DIFF
--- a/date.h
+++ b/date.h
@@ -4063,7 +4063,7 @@ format(std::basic_string<CharT, Traits> fmt, sys_time<Duration> tp)
 {
     const std::string abbrev("UTC");
     CONSTDATA std::chrono::seconds offset{0};
-    return detail::format(std::move(fmt), local_time<Duration>{tp.time_since_epoch()},
+    return detail::format(std::locale{}, std::move(fmt), local_time<Duration>{tp.time_since_epoch()},
                           &abbrev, &offset);
 }
 

--- a/date.h
+++ b/date.h
@@ -39,6 +39,7 @@
 #include <ostream>
 #include <ratio>
 #include <type_traits>
+#include <sstream>
 
 namespace date
 {

--- a/date.h
+++ b/date.h
@@ -40,6 +40,7 @@
 #include <ratio>
 #include <type_traits>
 #include <sstream>
+#include <cctype>
 
 namespace date
 {


### PR DESCRIPTION
Solution: 
- add missing locale (first parameter is always locale)
- add missing include to *sstream* since basic_ostringstream is incomplete 