### PR TITLE
Problem: time_points with a finer resolution than system_clock::duration cannot be formated

### DIFF
--- a/date.h
+++ b/date.h
@@ -4015,7 +4015,7 @@ format(const std::locale& loc, std::basic_string<CharT, Traits> fmt,
     }
     auto& f = use_facet<time_put<CharT>>(loc);
     basic_ostringstream<CharT, Traits> os;
-    auto tt = system_clock::to_time_t(sys_time<Duration>{tp.time_since_epoch()});
+    auto tt = system_clock::to_time_t(time_point_cast<system_clock::duration>(sys_time<Duration>{tp.time_since_epoch()}));
     std::tm tm{};
 #ifndef _MSC_VER
     gmtime_r(&tt, &tm);


### PR DESCRIPTION
Soiution: cast them to system_clock::duration for the function call *to_time_t*. This shouldn't do any harm since the fractions of the second are handled maually before...