### PR TITLE
Fix for issue #79.

### DIFF
--- a/date.h
+++ b/date.h
@@ -4167,6 +4167,7 @@ parse(std::basic_istream<CharT, Traits>& is,
                 {
                     f.get(is, 0, is, err, &tm, b, i-1);
                     if( err & ios_base::failbit ) {
+                      command = modified = false;
                       break; // break the switch/case
                     }
                     b = i+1;
@@ -4175,6 +4176,7 @@ parse(std::basic_istream<CharT, Traits>& is,
                         const CharT hm[] = {'%', 'H', ':', '%', 'M', ':'};
                         f.get(is, 0, is, err, &tm, hm, hm+6);
                         if( err & ios_base::failbit ) {
+                          command = modified = false;
                           break; // break the switch/case
                         }
                     }

--- a/date.h
+++ b/date.h
@@ -4149,7 +4149,7 @@ parse(std::basic_istream<CharT, Traits>& is,
         auto e = b + format.size();
         auto command = false;
         auto modified = false;
-        for (; i < e; ++i)
+        for (; (i < e) && (0 == (err & ios_base::failbit)); ++i)
         {
             switch (*i)
             {
@@ -4166,11 +4166,17 @@ parse(std::basic_istream<CharT, Traits>& is,
                 if (command && !modified)
                 {
                     f.get(is, 0, is, err, &tm, b, i-1);
+                    if( err & ios_base::failbit ) {
+                      break; // break the switch/case
+                    }
                     b = i+1;
                     if (*i == 'T')
                     {
                         const CharT hm[] = {'%', 'H', ':', '%', 'M', ':'};
                         f.get(is, 0, is, err, &tm, hm, hm+6);
+                        if( err & ios_base::failbit ) {
+                          break; // break the switch/case
+                        }
                     }
                     if (ratio_less<typename Duration::period, ratio<1>>::value)
                     {


### PR DESCRIPTION
Essentially:

- additionally breaking the `for` cycle at the first `err & ios_base::failbit`

- breaking the `case 'T'` if any of the delegation calls to the `f.get(...)` raises the ` ios_base::failbit` in `err`. Together with the additional cycle condition above, this should fix the bug.

I'm not sure though if this is enough: the `EOF` or `bad stream` conditions doesn't seem to be treated in the whole code of the affected function - maybe the tests should be expressed in terms of `ios_base::goodbit` and the entire processing abandoned as soon as the goodbit is zero?