### PR TITLE
Clang on Fedora needs <climits> for the CHAR_BIT definition.

### DIFF
--- a/iso_week.h
+++ b/iso_week.h
@@ -25,6 +25,8 @@
 
 #include "date.h"
 
+#include <climits>
+
 namespace iso_week
 {
 


### PR DESCRIPTION
On my Fedora 24 box, Clang 3.8 needs an additional include directive in order to compile all tests successfully.