### PR TITLE
Issue #88 regarding the ostream support for `date::format`

### DIFF
--- a/date.h
+++ b/date.h
@@ -3775,11 +3775,12 @@ public:
         os.width(2);
         os << std::abs(t.m_.count()) << ':';
         os.width(2);
-        os << std::abs(t.s_.count())
-           << use_facet<numpunct<char>>(os.getloc()).decimal_point();
-        os.imbue(locale{});
+        os << std::abs(t.s_.count());
+//      No need to echo the decimal separator any more, the time_subsec_put will do it alright
+//           << use_facet<numpunct<char>>(os.getloc()).decimal_point();
+//        os.imbue(locale{});
 
-        time_subsec_put<Period>::put(os, t.sub_s_.count());
+        time_subsec_put<Period>::put(os, t.sub_s_);
 
 //#if __cplusplus >= 201402
 //        CONSTDATA auto cl10 = ceil_log10(Period::den);
@@ -3995,7 +3996,7 @@ direct_stream(std::basic_ostream<CharT, Traits>& os, std::basic_string<CharT, Tr
 //            if (command && !modified && ratio_less<typename Duration::period,
 //                                                   ratio<1>>::value)
             { // the block can stay as a nest for this local type alias
-                using subsecput_type = time_subsec_put<typename Duration::period>;
+                using subsecput_type = time_subsec_insert<typename Duration::period>;
                 if(command && !modified && subsecput_type::admits_subsecs) {
                   // skip over the T or S
                   ++i;

--- a/subsecs.h
+++ b/subsecs.h
@@ -99,7 +99,7 @@ private:
   // specialization above is preferred.
   template <std::uintmax_t v, std::uintmax_t b>
   struct floor_log_tag<false, v, b> {
-    static CONSTDATA unsigned value=1;
+    static CONSTDATA unsigned value=0; // needs to be zero, we'll be adding 1 because it has_reminder
     static CONSTDATA bool     has_reminder=1;
   };
 

--- a/subsecs.h
+++ b/subsecs.h
@@ -267,8 +267,6 @@ struct time_subsec_put {
     return os;
   }
 };
-#undef POW10
-#undef CEIL_LOG10
 
 } // namespace detail
 } // namespace date

--- a/subsecs.h
+++ b/subsecs.h
@@ -1,38 +1,44 @@
 /*
  * subsecs.h
- * Created on: 16 Sep 2016
+ *
+ *  Created on: 16 Sep 2016
  *      Author: acolomitchi
  *
- * The MIT License (MIT)
-//
+ * The no-shouting MIT License (ns-MIT)
+ *
  * Copyright (c) 2016 Adrian Colomitchi
-//
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
-//
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
-//
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ *
+ * Disclaimer (no longer in All-Caps but still exonerating the authors and/or
+ * copyright holders):
+ *
+ * The software is provided "as is", without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose and noninfringement. In no event shall the
+ * authors or copyright holders be liable for any claim, damages or other
+ * liability, whether in an action of contract, tort or otherwise, arising from,
+ * out of or in connection with the software or the use or other dealings in the
+ * software.
  */
 
 #ifndef SUBSECS_H_
 #define SUBSECS_H_
 
-#include <iostream>
+#include <chrono>
+#include <ostream>
 #include <limits>
 #include <locale>
 #include <string>
+#include <type_traits>
 
 #if defined(_MSC_VER) && ! defined(__clang__)
 // MS cl compiler.
@@ -56,25 +62,16 @@
 
 
 namespace date {
+// forward declaration: this should disappear anyway if/when the content
+// of this header is cannibalized into the appropriate place in `date.h`
+template <class To, class Rep, class Period>
+CONSTCD14 To floor(const std::chrono::duration<Rep, Period>& d);
+
 namespace detail {
-
-
-// Like std::enable_if, but for values
-template <bool, typename T, T v>
-struct v_enable_if;
-
-template <typename T, T v>
-struct v_enable_if<false, T, v> {
-};
-
-template <typename T, T v>
-struct v_enable_if<true,T,v> {
-  static CONSTDATA T value=v;
-};
 
 template <std::uintmax_t val, std::uintmax_t base>
 struct ceil_log_struct {
-
+private:
   // need one level of indirection to arrest infinite recursion upon
   // checking '(value<b)' stop condition
   template <bool, std::uintmax_t v, std::uintmax_t b=10>
@@ -92,13 +89,13 @@ struct ceil_log_struct {
     static CONSTDATA unsigned value=ceil_log_struct<v/b, b>::value + 1;
   };
 
+  using sfinae_guard_type=typename std::enable_if<
+      (base>1) // don't accept base of 0 or 1, they don't make sense
+  >::type;
+public:
   static CONSTDATA unsigned value=
-      v_enable_if<
-          (base>1), // don't accept base of 0 or 1, they don't make sense
-          unsigned,
-          nl_len_tag<(val>base), val, base>::value
-      >::value
-  ;
+      nl_len_tag<(val>base), val, base>::value;
+
 };
 
 // ------
@@ -143,6 +140,7 @@ struct pow_struct<0,base>
 // a necessary price to pay for compile-time loop unrolling
 template <unsigned width, typename T=std::uintmax_t>
 struct decimals_fmt {
+private:
   // allow floating point representation as well, they go OK after sign elimination
   using type=typename std::enable_if<std::is_arithmetic<T>::value, T>::type;
 
@@ -160,7 +158,7 @@ struct decimals_fmt {
     value %= max_val;
     return value;
   }
-
+public:
   template <typename CharT=char>
   void put(
     std::basic_string<CharT>& dest,
@@ -192,8 +190,9 @@ struct decimals_fmt {
 
 template <typename U>
 struct decimals_fmt<0, U> {
+private:
   using type=typename std::enable_if<std::is_arithmetic<U>::value, U>::type;
-
+public:
   template <typename CharT=char>
   void put(std::basic_string<CharT>& dest,std::size_t& inspos, type val)
   { // with a width of zero, nothing happens;
@@ -210,90 +209,140 @@ struct decimals_fmt<0, U> {
 
 template <class SrcPeriod>
 struct time_subsec_put {
-  // A more relaxed condition than the (num < den)
-  // Any already reduced rational fraction with den>1 will
-  // cause decimals (if it didn't, then it would be an integer)
-  static CONSTDATA bool admits_subsecs= (SrcPeriod::den!=1);
 
-  // refuse to deal with values greater than seconds, thus require
-  // SrcPeriod::num strictly less than SrcPeriod::den.
-  // Heuristic: denominator also carry the required precision
-  static CONSTDATA std::uintmax_t max_val=
-      POW10(CEIL_LOG10(SrcPeriod::den))
-  ;
+private:
+  // one extra level of indirection to deal with has/has-not subsecs
+  template <bool has_subsecs,class Period=SrcPeriod> struct delegate;
 
-  // the 'width' occupied by the digits.
-  static CONSTDATA unsigned precision=CEIL_LOG10(max_val);
+  // this specialization will be chosen when the Period has subseconds
+  template <class Period> struct delegate<true, Period> {
+    template <typename Rep> using dur_type=std::chrono::duration<Rep, Period>;
+    template <class Clock, typename Rep> using tp_type=
+        std::chrono::time_point<Clock, dur_type<Rep>>;
 
-  // This is the space needed to output the subseconds value in full precision,
-  // including the decimal dot.
-  static CONSTDATA unsigned space_req=precision+1;
+    // Heuristic: denominator also carry the required precision
+    static CONSTDATA std::uintmax_t max_val=
+        POW10(CEIL_LOG10(Period::den))
+    ;
+
+    // the 'width' occupied by the digits.
+    static CONSTDATA unsigned precision=CEIL_LOG10(max_val);
+
+    // This is the space needed to output the subseconds value in full precision,
+    // including the decimal dot.
+    static CONSTDATA unsigned space_req=precision+1;
 
 
-  // precomputed scale factor to be applied to received counts
-  static CONSTDATA long double scale_factor=
-    1.0L*max_val*SrcPeriod::num/SrcPeriod::den
-  ;
+    // precomputed scale factor to be applied to received counts
+    static CONSTDATA long double scale_factor=
+      1.0L*max_val*Period::num/Period::den
+    ;
 
-  // Because we are supposed to deal with **sub**-seconds, anything that goes
-  // above max_val is discarded (we only keep the lesser-significant digits)
-  template <typename Rep> Rep condition_value(Rep count) {
-    std::uintmax_t scaled=static_cast<std::uintmax_t>(scale_factor*count);
-    return static_cast<Rep>(scaled % max_val);
-  }
+    // Because we are supposed to deal with **sub**-seconds, anything that goes
+    // above max_val is discarded (we only keep the lesser-significant digits)
+    template <class Clock, typename Rep>
+    static Rep condition_value(tp_type<Clock, Rep> tp) {
+      // obtain the subseconds here: must use auto to adjust for odd ratios (likw 355/113)
+      auto subsecs=tp-floor<std::chrono::seconds>(tp);
+      std::uintmax_t scaled=static_cast<std::uintmax_t>(scale_factor*subsecs.count());
+      return static_cast<Rep>(scaled % max_val);
+    }
 
-  // for periods that do have subseconds
-  template <typename Rep,typename CharT>
-  void insert(
-    std::basic_string<CharT>& dest,
-    std::size_t& inspos,
-    std::chrono::duration<Rep, SrcPeriod> duration,
-    const std::locale& loc
-  )
-  {
-    if(admits_subsecs) {
-      // scale the count
-      Rep count=condition_value(duration.count());
+    // for periods that do have subseconds
+    template <typename Clock, typename Rep, typename CharT, typename CharTraits>
+    static void insert(
+      std::basic_string<CharT, CharTraits>& dest,
+      std::size_t& inspos,
+      tp_type<Clock, Rep> tp,
+      const std::locale& loc
+    )
+    {
+      // obtain the conditioned subseconds here
+      Rep subsecs=condition_value(tp);
       // make room for the content in the destination
       dest.insert(inspos, space_req, ' ');
       // insert the decimal dot
       CharT dotChar=std::use_facet<std::numpunct<CharT>>(loc).decimal_point();
       dest[inspos]=dotChar;
       inspos++;
-      // prepare the filler
-      decimals_fmt<precision, Rep> filler;
-      // output the value
-      filler.put(dest, inspos, count);
+      // prepare the decimals formatter
+      decimals_fmt<precision, Rep> formatter;
+      // render the value
+      formatter.put(dest, inspos, subsecs);
     }
-  }
 
-  // In ostream
-  // Periods with subseconds
-  template <typename Rep, typename CharT=char>
-  std::basic_ostream<CharT>& put(
-      std::basic_ostream<CharT>& os,
-      std::chrono::duration<Rep,SrcPeriod> count
-  )
-  {
-    if(admits_subsecs) {
-      // scale the count
-      count=condition_value(count);
+    // In ostream
+    // Periods with subseconds
+    template <typename Clock, typename Rep, typename CharT, typename CharTraits>
+    static std::basic_ostream<CharT>& put(
+        std::basic_ostream<CharT, CharTraits>& os,
+        tp_type<Clock, Rep> tp
+    )
+    {
+      // obtain the conditioned subseconds here
+      Rep subsecs=condition_value(tp);
       // insert the decimal dot
       os << std::use_facet<std::numpunct<CharT>>(os.getloc()).decimal_point();
-      // prepare the filler
-      decimals_fmt<precision, Rep> filler;
+      // prepare the formatter
+      decimals_fmt<precision, Rep> formatter;
       // echo the value
-      filler.put(os, count);
+      formatter.put(os, subsecs);
+      return os;
     }
-    return os;
+  };
+
+  // this specialization will be chosen when the Period does not have subseconds
+  template <class Period> struct delegate<false, Period> {
+    template <typename Rep> using dur_type=std::chrono::duration<Rep, Period>;
+    template <class Clock, typename Rep> using tp_type=
+        std::chrono::time_point<Clock, dur_type<Rep>>;
+    template <class Clock, typename Rep,typename CharT, typename CharTraits>
+    static void insert(
+        std::basic_string<CharT, CharTraits>& dest,
+        std::size_t& inspos,
+        tp_type<Clock, Rep> tp,
+        const std::locale& loc
+    ) { // do nothing, no subsecs
+    }
+    template <class Clock, typename Rep, typename CharT, typename CharTraits>
+    static std::basic_ostream<CharT>& put(
+        std::basic_ostream<CharT,CharTraits>& os,
+        tp_type<Clock, Rep> tp
+    ) {// do nothing, no subsecs
+      return os;
+    }
+  };
+public:
+  // A more relaxed condition than the (num < den)
+  // Any already reduced rational fraction with den>1 will
+  // cause decimals (if it didn't, then it would be an integer)
+  static CONSTDATA bool admits_subsecs= (SrcPeriod::den!=1);
+
+  // delegating the methods based on the admits/doesn't admit subseconds
+  template <class Clock, typename Rep,typename CharT, typename CharTraits>
+  static void insert(
+      std::basic_string<CharT, CharTraits>& dest,
+      std::size_t& inspos,
+      std::chrono::time_point<Clock, std::chrono::duration<Rep,SrcPeriod>> tp,
+      const std::locale& loc
+  ) {
+    delegate<admits_subsecs, SrcPeriod>::insert(dest, inspos, tp, loc);
+  }
+  template <class Clock, typename Rep, typename CharT, typename CharTraits>
+  static std::basic_ostream<CharT>& put(
+      std::basic_ostream<CharT,CharTraits>& os,
+      std::chrono::time_point<Clock, std::chrono::duration<Rep,SrcPeriod>> tp
+  ) {
+    return delegate<admits_subsecs, SrcPeriod>::put(os, tp);
   }
 };
+#undef POW10
+#undef CEIL_LOG10
 
 } // namespace detail
 } // namespace date
 
-#undef CEIL_LOG10
-#undef POW10
+
 #undef CONSTDATA
 #undef CONSTCD11
 #undef CONSTCD14

--- a/subsecs.h
+++ b/subsecs.h
@@ -1,0 +1,282 @@
+/*
+ * subsecs.h
+ *
+ *  Created on: 16 Sep 2016
+ *      Author: acolomitchi
+ */
+
+#ifndef SUBSECS_H_
+#define SUBSECS_H_
+
+#include <iostream>
+#include <limits>
+#include <locale>
+#include <string>
+
+#if defined(_MSC_VER) && ! defined(__clang__)
+// MS cl compiler.
+#  define CONSTDATA const
+#  define CONSTCD11
+#  define CONSTCD14
+#  define NOEXCEPT _NOEXCEPT
+#elif __cplusplus >= 201402
+// C++14
+#  define CONSTDATA constexpr
+#  define CONSTCD11 constexpr
+#  define CONSTCD14 constexpr
+#  define NOEXCEPT noexcept
+#else
+// C++11
+#  define CONSTDATA constexpr
+#  define CONSTCD11 constexpr
+#  define CONSTCD14
+#  define NOEXCEPT noexcept
+#endif
+
+
+namespace date {
+namespace detail {
+
+
+// Like std::enable_if, but for values
+template <bool, typename T, T v>
+struct v_enable_if;
+
+template <typename T, T v>
+struct v_enable_if<false, T, v> {
+};
+
+template <typename T, T v>
+struct v_enable_if<true,T,v> {
+  static CONSTDATA T value=v;
+};
+
+template <std::uintmax_t val, std::uintmax_t base>
+struct ceil_log_struct {
+
+  // need one level of indirection to arrest infinite recursion upon
+  // checking '(value<b)' stop condition
+  template <bool, std::uintmax_t v, std::uintmax_t b=10>
+  struct nl_len_tag;
+
+  // recursion will stop when the (val < b), the literal length will be 1
+  template <std::uintmax_t v, std::uintmax_t b>
+  struct nl_len_tag<false, v, b> {
+    static CONSTDATA unsigned value=1;
+  };
+
+  // if val>=b, call numliteral_len with val/b and add one to the returned value
+  template <std::uintmax_t v, std::uintmax_t b>
+  struct nl_len_tag<true, v, b> {
+    static CONSTDATA unsigned value=ceil_log_struct<v/b, b>::value + 1;
+  };
+
+  static CONSTDATA unsigned value=
+      v_enable_if<
+          (base>1), // don't accept base of 0 or 1, they don't make sense
+          unsigned,
+          nl_len_tag<(val>base), val, base>::value
+      >::value
+  ;
+};
+
+// ------
+// ***Warning: note the unusual order of (power, base) for the parameters
+// *** due to the default val for the base
+
+template <unsigned long exponent, std::uintmax_t base=10>
+struct pow_struct
+{
+private:
+  static CONSTDATA std::uintmax_t at_half_pow=pow_struct<exponent / 2, base>::value;
+public:
+  static CONSTDATA std::uintmax_t value=
+      at_half_pow*at_half_pow*(exponent % 2 ? base : 1)
+  ;
+};
+
+template <std::uintmax_t base>
+struct pow_struct<1, base>
+{
+  static CONSTDATA long long value=base;
+};
+
+
+template <std::uintmax_t base>
+struct pow_struct<0,base>
+{
+  static CONSTDATA long long value=1;
+};
+
+#define POW10(width) (pow_struct<(width), 10>::value)
+#define CEIL_LOG10(val) (ceil_log_struct<(val),10>::value)
+
+
+// Inserting a right-aligned, 0-filled literal representation in base10
+// of an integral number of type T, strictly obeying the limits of a specified
+// width (number of characters available). Discards the sign
+// if the presented value is signed and is negative.
+// If the provided number does not fit into the allocated width,
+// ***it will throw away the overflow, representing only the
+// less-significant-digits*** - if I'm not mistaken, this is
+// a necessary price to pay for compile-time loop unrolling
+template <unsigned width, typename T=std::uintmax_t>
+struct decimals_fmt {
+  // allow floating point representation as well, they go OK after sign elimination
+  using type=typename std::enable_if<std::is_arithmetic<T>::value, T>::type;
+
+  // the maximum unsigned value representable on 'width' digits
+  static CONSTDATA std::uintmax_t max_val=POW10(width);
+
+  // what the first value we should use for the division to get the first digit
+  static CONSTDATA std::uintmax_t div_val=max_val/10;
+
+  static type condition_value(const type val) {
+    // discard the sign.
+    type value=(val>=0 ? val : -val);
+    // if it's greater or equal than the max_val (thus 'width' is not large enough)...
+    //  ... then won't be able to deal with the excess, so just keep only the remainder
+    value %= max_val;
+    return value;
+  }
+
+  template <typename CharT=char>
+  void put(
+    std::basic_string<CharT>& dest,
+    std::size_t& inspos, type val
+  )
+  {
+    type value=condition_value(val);
+    CharT toIns=static_cast<CharT>('0'+(value / div_val));
+    dest[inspos]=toIns;
+    // advance and unroll one step further
+    ++inspos;
+    decimals_fmt<width-1, T> unrolled; // the compiler MUST evaluate this
+    unrolled.put(dest, inspos, value % div_val);
+  }
+
+
+  // let's do something similar for appending in an ostream
+  template <typename CharT=char>
+  std::basic_ostream<CharT>&
+  put(std::basic_ostream<CharT>& os, type value)
+  {
+    value=condition_value(value);
+    os << static_cast<CharT>('0'+(value / div_val));
+    // unroll one step further
+    decimals_fmt<width-1, T> unrolled; // the compiler MUST evaluate this
+    return unrolled.put(os, value % div_val);
+  }
+};
+
+template <typename U>
+struct decimals_fmt<0, U> {
+  using type=typename std::enable_if<std::is_arithmetic<U>::value, U>::type;
+
+  template <typename CharT=char>
+  void put(std::basic_string<CharT>& dest,std::size_t& inspos, type val)
+  { // with a width of zero, nothing happens;
+  }
+
+  template <typename CharT=char>
+  std::basic_ostream<CharT>&
+  put(std::basic_ostream<CharT>& os, type value)
+  { // with a width of zero, nothing happens;
+    return os;
+  }
+};
+
+
+template <class SrcPeriod>
+struct time_subsec_put {
+  // A more relaxed condition than the (num < den)
+  // Any already reduced rational fraction with den>1 will
+  // cause decimals (if it didn't, then it would be an integer)
+  static CONSTDATA bool admits_subsecs= (SrcPeriod::den!=1);
+
+  // refuse to deal with values greater than seconds, thus require
+  // SrcPeriod::num strictly less than SrcPeriod::den.
+  // Heuristic: denominator also carry the required precision
+  static CONSTDATA std::uintmax_t max_val=
+      POW10(CEIL_LOG10(SrcPeriod::den))
+  ;
+
+  // the 'width' occupied by the digits.
+  static CONSTDATA unsigned precision=CEIL_LOG10(max_val);
+
+  // This is the space needed to output the subseconds value in full precision,
+  // including the decimal dot.
+  static CONSTDATA unsigned space_req=precision+1;
+
+
+  // precomputed scale factor to be applied to received counts
+  static CONSTDATA long double scale_factor=
+    1.0L*max_val*SrcPeriod::num/SrcPeriod::den
+  ;
+
+  // Because we are supposed to deal with **sub**-seconds, anything that goes
+  // above max_val is discarded (we only keep the lesser-significant digits)
+  template <typename Rep> Rep condition_value(Rep count) {
+    std::uintmax_t scaled=static_cast<std::uintmax_t>(scale_factor*count);
+    return static_cast<Rep>(scaled % max_val);
+  }
+
+  // for periods that do have subseconds
+  template <typename Rep,typename CharT>
+  void insert(
+    std::basic_string<CharT>& dest,
+    std::size_t& inspos,
+    std::chrono::duration<Rep, SrcPeriod> duration,
+    const std::locale& loc
+  )
+  {
+    if(admits_subsecs) {
+      // scale the count
+      Rep count=condition_value(duration.count());
+      // make room for the content in the destination
+      dest.insert(inspos, space_req, ' ');
+      // insert the decimal dot
+      CharT dotChar=std::use_facet<std::numpunct<CharT>>(loc).decimal_point();
+      dest[inspos]=dotChar;
+      inspos++;
+      // prepare the filler
+      decimals_fmt<precision, Rep> filler;
+      // output the value
+      filler.put(dest, inspos, count);
+    }
+  }
+
+  // In ostream
+  // Periods with subseconds
+  template <typename Rep, typename CharT=char>
+  std::basic_ostream<CharT>& put(
+      std::basic_ostream<CharT>& os,
+      std::chrono::duration<Rep,SrcPeriod> count
+  )
+  {
+    if(admits_subsecs) {
+      // scale the count
+      count=condition_value(count);
+      // insert the decimal dot
+      os << std::use_facet<std::numpunct<CharT>>(os.getloc()).decimal_point();
+      // prepare the filler
+      decimals_fmt<precision, Rep> filler;
+      // echo the value
+      filler.put(os, count);
+    }
+    return os;
+  }
+};
+#undef POW10
+#undef CEIL_LOG10
+
+} // namespace detail
+} // namespace date
+
+
+#undef CONSTDATA
+#undef CONSTCD11
+#undef CONSTCD14
+#undef NOEXCEPT
+
+#endif /* SUBSECS_H_ */

--- a/subsecs.h
+++ b/subsecs.h
@@ -1,8 +1,29 @@
 /*
  * subsecs.h
- *
- *  Created on: 16 Sep 2016
+ * Created on: 16 Sep 2016
  *      Author: acolomitchi
+ *
+ * The MIT License (MIT)
+//
+ * Copyright (c) 2016 Adrian Colomitchi
+//
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+//
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+//
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 #ifndef SUBSECS_H_
@@ -271,7 +292,8 @@ struct time_subsec_put {
 } // namespace detail
 } // namespace date
 
-
+#undef CEIL_LOG10
+#undef POW10
 #undef CONSTDATA
 #undef CONSTCD11
 #undef CONSTCD14


### PR DESCRIPTION
PR for issue #88 created. As the additions to address the

>  it will still have to create ostringstream internally for `%z` and for `%S` and `%T`

are non-trivial (they are supported mainly in the  `subsecs.h` file), it will take a bit to get through all the changes in the next comment)
