### PR TITLE
Continuous Integration (Windows, Linux, OS X)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+sudo: required
+
+language: cpp
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.8 main'
+    packages:
+      # This is the minimum GCC compiler version needed to compile the tz test
+      - g++-4.8
+      # This is the minimum GCC compiler version needed to compile and run the
+      # full test suite with clang using libstdc++
+      - g++-6
+      - clang-3.8
+      - libcurl4-openssl-dev
+
+matrix:
+  include:
+    - dist: trusty
+      os: linux
+      compiler: gcc
+      env: COMPILER=g++-4.8 CXX_LANG=c++11 OPTIONS=-O3 TEST_ALL=0
+    - dist: trusty
+      os: linux
+      compiler: gcc
+      # The test suite does not compile with gcc 6 because of a brace
+      # initialization bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67631
+      env: COMPILER=g++-6 CXX_LANG=c++14 OPTIONS=-O3 TEST_ALL=0
+    - dist: trusty
+      os: linux
+      compiler: clang
+      env: COMPILER=clang++-3.8 CXX_LANG=c++14 OPTIONS=-O3 TEST_ALL=1
+    - os: osx
+      osx_image: xcode7.3
+      # This will use a clang version similar to 3.8
+      compiler: clang
+      env: COMPILER=clang++ CXX_LANG=c++14 OPTIONS=-O3 TEST_ALL=1
+
+branches:
+  except:
+    - gh_pages
+
+script:
+  # We are either just compiling the tz test program or are running
+  # the full test suite (only clang can do so currently).
+  - $COMPILER -v
+  - if [[ "$TEST_ALL" -eq "0" ]] ; then $COMPILER -std=$CXX_LANG -Wall -I. tz.cpp test/tz_test/validate.cpp -lcurl ; fi
+  - if [[ "$TEST_ALL" -eq "1" ]] ; then cd test && CXX=$COMPILER ./testit                                          ; fi
+
+
+

--- a/README.md
+++ b/README.md
@@ -25,3 +25,26 @@ This is actually several separate C++11/C++14 libraries:
 There has been a recent change in the library design.  If you are trying to migrate from the previous design, rename `day_point` to `sys_days` everywhere, and that ought to bring the number of errors down to a small roar.
 
 `"date.h"` and `"tz.h"` are now proposed for standardization here:  http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0355r0.html
+
+--
+
+Continuous integration status:
+
+[![Linux Build Status](https://img.shields.io/travis/HowardHinnant/date/master.svg?style=flat-square&label=Linux%20%26%20OS%20X)](http://travis-ci.org/HowardHinnant/date) | Platform | Configuration | Test
+------------------------------ | --- | --- | -----------------
+GCC 4.8                        | x64 | -O3 | tz compilation
+GCC 6.2                        | x64 | -O3 | tz compilation
+Clang 3.8 (with libstdc++-6.2) | x64 | -O3 | all
+XCode 7.3                      | x64 | -O3 | all
+
+
+[![Windows Build status](https://img.shields.io/appveyor/ci/HowardHinnant/date/master.svg?style=flat-square&label=Windows)](https://ci.appveyor.com/project/HowardHinnant/date/branch/master) | Platform | Configuration | Test
+------- | --- | ------- | ----------------
+VS 2013 | x32 | Debug   | tz compilation
+VS 2013 | x32 | Release | tz compilation
+VS 2013 | x64 | Debug   | tz compilation
+VS 2013 | x64 | Release | tz compilation
+VS 2015 | x32 | Debug   | tz compilation
+VS 2015 | x32 | Release | tz compilation
+VS 2015 | x64 | Debug   | tz compilation
+VS 2015 | x64 | Release | tz compilation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+version: 2.x.{build}
+pull_requests:
+  do_not_increment_build_number: true
+
+branches:
+  except:
+    - gh_pages
+
+skip_tags: true
+
+image:
+  - Visual Studio 2013
+  - Visual Studio 2015
+
+configuration:
+  - Debug
+  - Release
+
+platform:
+  - x64
+  - Win32
+
+init:
+  - cmd: git config --global core.autocrlf true
+
+# We only build the tz test program, the actual tests are not
+# supported / integrated yet.
+build_script:
+  - cmd: >-
+      if "%platform%"=="x64" if "%VS140COMNTOOLS%"=="" call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
+
+      if "%platform%"=="Win32" if "%VS140COMNTOOLS%"=="" call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
+
+      if "%platform%"=="x64" if NOT "%VS140COMNTOOLS%"=="" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+
+      if "%platform%"=="Win32" if NOT "%VS140COMNTOOLS%"=="" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+
+      if "%configuration%"=="Release" cl tz.cpp test/tz_test/validate.cpp /EHsc /W3 /WX /I. /D "NDEBUG" /O2 /link "shell32.lib" "ole32.lib" "advapi32.lib" 2>&1
+
+      if "%configuration%"=="Debug" cl tz.cpp test/tz_test/validate.cpp /EHsc /W3 /WX /I. /MDd /D "_DEBUG" /link "shell32.lib" "ole32.lib" "advapi32.lib" 2>&1
+
+

--- a/test/tz_test/zone.pass.cpp
+++ b/test/tz_test/zone.pass.cpp
@@ -11,5 +11,16 @@ main()
     static_assert(!is_copy_constructible<time_zone>{}, "");
     static_assert(!is_copy_assignable<time_zone>{}, "");
     static_assert( is_nothrow_move_constructible<time_zone>{}, "");
+
+    // The libstdc++ ABI depends on the OS version. On older Linux
+    // distributions, the pre-C++11 ABI is used, which means the old
+    // std::string definitions are used, not declaring certain functions
+    // and operators noexcept. So even when using gcc 6, the move
+    // assignment operator for std::string is not noexcept.
+
+#if !defined(__GLIBCXX__) || (_GLIBCXX_USE_CXX11_ABI > 0)
     static_assert( is_nothrow_move_assignable<time_zone>{}, "");
+#else
+    static_assert( is_move_assignable<time_zone>{}, "");
+#endif
 }


### PR DESCRIPTION
Not sure if you are interested in this, but this PR adds continuous integration support via Travis CI and Appveyor. It uses GCC (Linux), Clang (Linux & OS X), Visual Studio 2013, and Visual Studio 2015.

Only the Clang (Linux & OS X) builds run the full test suite. For the Linux version, I had to slightly modify the `zone` test to only check `timezone` move assignment (without nothrow) in case of using non C++11 ABI with libstdc++11 (the Travis CI infrastructure only provides Ubuntu 14.04 which does not use the newer C++11 ABI). I thought it is worth having the full test suite also running on Linux via Clang.

The modified readme contains a table with all the CI tests, you can look at it in my fork:

https://github.com/saschazelzer/date/tree/ci-support
