### PR TITLE
Add support for setting path to timezone database dynamically.

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -218,7 +218,12 @@ static std::string get_install()
 
 #ifndef INSTALL
 
-static const std::string install = get_install();
+static std::string install = get_install();
+
+void set_install(std::string install_folder)
+{
+   install = install_folder;
+}
 
 #else   // INSTALL
 

--- a/tz.cpp
+++ b/tz.cpp
@@ -228,12 +228,6 @@ get_install()
 #  else
     = expand_path("~/Downloads/tzdata");
 #  endif
-}
-
-void set_install(std::string install_folder)
-{
-    install = install_folder;
-}
 
 #else   // INSTALL
 
@@ -245,6 +239,11 @@ void set_install(std::string install_folder)
 #endif  // INSTALL
 
     return install;
+}
+
+void set_install(std::string install_folder)
+{
+    install = install_folder;
 }
 
 static

--- a/tz.cpp
+++ b/tz.cpp
@@ -214,15 +214,9 @@ namespace date
 
 using namespace detail;
 
-static std::string install;
+static std::string install
 
-static
-const std::string&
-get_install()
-{
-    install
 #ifndef INSTALL
-
 #  ifdef _WIN32
     = get_download_folder() + folder_delimiter + "tzdata";
 #  else
@@ -234,10 +228,14 @@ get_install()
 #  define STRINGIZEIMP(x) #x
 #  define STRINGIZE(x) STRINGIZEIMP(x)
 
-    = STRINGIZE(INSTALL) + std::string(1, folder_delimiter) + "tzdata";
+       = STRINGIZE(INSTALL) + std::string(1, folder_delimiter) + "tzdata";
 
 #endif  // INSTALL
 
+static
+const std::string&
+get_install()
+{
     return install;
 }
 

--- a/tz.cpp
+++ b/tz.cpp
@@ -228,6 +228,7 @@ get_install()
 #  else
     = expand_path("~/Downloads/tzdata");
 #  endif
+}
 
 void set_install(std::string install_folder)
 {

--- a/tz.h
+++ b/tz.h
@@ -763,6 +763,10 @@ bool        remote_download(const std::string& version);
 bool        remote_install(const std::string& version);
 #endif
 
+#ifndef INSTALL
+void set_install(std::string install_folder);
+#endif
+
 const time_zone* locate_zone(const std::string& tz_name);
 #ifdef TZ_TEST
 #  if _WIN32


### PR DESCRIPTION
This patch adds a function set_install() if INSTALL is not defined.

This is very useful on Windows, where you cannot be sure that any "standard" path exists.