### PR TITLE
resolve /etc/localtime to its final destination

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -3,7 +3,7 @@
 // Copyright (c) 2015, 2016 Howard Hinnant
 // Copyright (c) 2015 Ville Voutilainen
 // Copyright (c) 2016 Alexander Kormanovsky
-// Copyright (c) 2016 Jiangang Zhuang
+// Copyright (c) 2016, 2017 Jiangang Zhuang
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -3094,14 +3094,20 @@ current_zone()
     // The path may also take a relative form:
     // "../usr/share/zoneinfo/America/Los_Angeles".
     struct stat sb;
-    CONSTDATA auto timezone = "/etc/localtime";
+    const char* timezone = "/etc/localtime";
     if (lstat(timezone, &sb) == 0 && S_ISLNK(sb.st_mode) && sb.st_size > 0)
     {
-        std::string result(sb.st_size, '\0');
-        auto sz = readlink(timezone, &result.front(), result.size());
-        if (sz == -1)
-            throw std::runtime_error("readlink failure");
-        result.resize(sz);
+        std::string result;
+        do
+        {
+            result.resize(sb.st_size, '\0');
+            auto sz = readlink(timezone, &result.front(), result.size());
+            if (sz == -1)
+                throw std::runtime_error("readlink failure");
+            timezone = result.c_str();
+        }
+        while (lstat(timezone, &sb) == 0 && S_ISLNK(sb.st_mode) && sb.st_size > 0);
+
         const char zonepath[] = "/usr/share/zoneinfo/";
         const std::size_t zonepath_len = sizeof(zonepath)/sizeof(zonepath[0])-1;
         const std::size_t pos = result.find(zonepath);


### PR DESCRIPTION
Sometimes the /etc/localtime points to another symlink. So, keep resolving the symlinks until it is no longer a symlink.

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION.  NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.