### PR TITLE
Enable CONSTCD14 for VS2017

### DIFF
--- a/date.h
+++ b/date.h
@@ -57,15 +57,22 @@ namespace date
 // Configuration |
 //---------------+
 
-// MSVC's constexpr support is still a WIP, even in VS2015.
-// Fall back to a lesser mode to support it.
-// TODO: Remove this or retest later once MSVC's constexpr improves.
-#if defined(_MSC_VER) && _MSC_VER <= 1900 && ! defined(__clang__)
-// MS cl compiler pre VS2017
+#if defined(_MSC_VER) && !defined(__clang__)
+// MSVC
+#if _MSC_VER < 1910
+// before VS2017
 #  define CONSTDATA const
 #  define CONSTCD11
 #  define CONSTCD14
 #  define NOEXCEPT _NOEXCEPT
+#else
+// VS2017 and later 
+#  define CONSTDATA constexpr const
+#  define CONSTCD11 constexpr
+#  define CONSTCD14 constexpr
+#  define NOEXCEPT noexcept
+#endif
+
 #elif __cplusplus >= 201402
 // C++14
 #  define CONSTDATA constexpr const


### PR DESCRIPTION
- already covered in PR #110, but there appears to be a bug with the `__cplusplus` macro in VS2017 RC (see comments in linked PR for more info)

- separate MSVC macro definitions from the generic ones; MSVC always seems to be an edge case, and this structure makes it easier to accommodate new versions if/when the need arises

- remove comments about legacy VS `constexpr` support

