### PR TITLE
Removing static to be compiled as library

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -190,7 +190,7 @@ get_download_folder()
 #else // !_WIN32
 
 
-static
+//static
 std::string
 expand_path(std::string path)
 {

--- a/tz.cpp
+++ b/tz.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2015 Ville Voutilainen
 // Copyright (c) 2016 Alexander Kormanovsky
 // Copyright (c) 2016, 2017 Jiangang Zhuang
+// Copyright (c) 2017 Nicolas Veloz Savino
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -189,8 +190,8 @@ get_download_folder()
 
 #else // !_WIN32
 
-
-//static
+#ifndef INSTALL
+static
 std::string
 expand_path(std::string path)
 {
@@ -205,6 +206,7 @@ expand_path(std::string path)
     return path;
 #endif
 }
+#endif
 
 #endif  // !_WIN32
 


### PR DESCRIPTION
making the function static doesn't allow to be compiled as a library when using -Werror