### PR TITLE
Create download folder when it does not exist on some UNIX system

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -2722,7 +2722,8 @@ remote_download(const std::string& version)
 #else
     // Create download folder if it does not exist on UNIX system
     auto download_folder = get_download_folder();
-    if (!file_exists(download_folder)) {
+    if (!file_exists(download_folder)) 
+    {
         make_directory(download_folder);
     }
 #endif
@@ -2751,7 +2752,6 @@ remote_install(const std::string& version)
 
     std::string install = get_install();
     auto gz_file = get_download_gz_file(version);
-
     if (file_exists(gz_file))
     {
         if (file_exists(install))


### PR DESCRIPTION
On some UNIX systems such as Debian servers in my case, the "~/Downloads" folder does not necessarily exists by default. Hence the following error throws : 

> terminate called after throwing an instance of 'std::runtime_error'
>  what():  Timezone database version "2017a" did not install correctly to "/home/user/Downloads/tzdata"

So I have changed _tz.cpp_ :

- Add a **get_download_folder()** function for !_WIN32 cases
- Factorize the **static std::string install** for both _WIN32 and !_WIN32 cases
- Add code to create the downloads folder if needed in **bool remote_download(const std::string&)** and move the latter definition just above **remote_install()** in order to be able to use **make_directory()**