### PR TITLE
Add a more generic approach to get UNIX download folder

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -2722,7 +2722,8 @@ remote_download(const std::string& version)
 #else
     // Create download folder if it does not exist on UNIX system
     auto download_folder = get_download_folder();
-    if (!file_exists(download_folder)) {
+    if (!file_exists(download_folder)) 
+    {
         make_directory(download_folder);
     }
 #endif
@@ -2751,7 +2752,6 @@ remote_install(const std::string& version)
 
     std::string install = get_install();
     auto gz_file = get_download_gz_file(version);
-
     if (file_exists(gz_file))
     {
         if (file_exists(install))


### PR DESCRIPTION
Download folder can differ (especially on non-english Linux distribution). 
The changes propose to stick with the download folder provided with the [xdg-user-dir](https://freedesktop.org/wiki/Software/xdg-user-dirs/) command which is available in most Linux distribution : 

- Add an exec_and_get_output function to grab the result of xdg-user-dir with popen
- Change get_download_folder() so that it uses the above function, verify whether the output is eligible. Result should always be a valid path. 
- Added copyright if this work can be useful
