### PR TITLE
Ignore annoying GCC 4.9 warning -Wmissing-field-initializers

### DIFF
--- a/date.h
+++ b/date.h
@@ -50,14 +50,12 @@
 #include <utility>
 #include <type_traits>
 
-#ifdef __GNUC__
-// GCC complains about __int128 with -pedantic or -pedantic-errors
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wpedantic"
 # if __GNUC__ < 5
+#  pragma GCC diagnostic push
+   // GCC 4.7 Bug 50454 complains about __int128 with -pedantic or -pedantic-errors
+#  pragma GCC diagnostic ignored "-Wpedantic"
    // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
 #endif
 
 namespace date

--- a/date.h
+++ b/date.h
@@ -50,12 +50,12 @@
 #include <utility>
 #include <type_traits>
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
 # if __GNUC__ < 5
-#  pragma GCC diagnostic push
-   // GCC 4.7 Bug 50454 complains about __int128 with -pedantic or -pedantic-errors
-#  pragma GCC diagnostic ignored "-Wpedantic"
    // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+# endif
 #endif
 
 namespace date
@@ -909,6 +909,12 @@ public:
         , loc_(os.getloc())
         {}
 };
+
+#ifdef __GNUC__
+// GCC complains about __int128 with -pedantic or -pedantic-errors
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 
 template <class T>
 struct choose_trunc_type

--- a/date.h
+++ b/date.h
@@ -50,6 +50,16 @@
 #include <utility>
 #include <type_traits>
 
+#ifdef __GNUC__
+// GCC complains about __int128 with -pedantic or -pedantic-errors
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+# if __GNUC__ < 5
+   // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
+#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+#endif
+
 namespace date
 {
 
@@ -902,12 +912,6 @@ public:
         {}
 };
 
-#ifdef __GNUC__
-// GCC complains about __int128 with -pedantic or -pedantic-errors
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-
 template <class T>
 struct choose_trunc_type
 {
@@ -928,10 +932,6 @@ struct choose_trunc_type
                      >::type
                  >::type;
 };
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
 template <class T>
 CONSTCD11
@@ -6589,5 +6589,11 @@ parse(const CharT* format, Parsable& tp,
 }
 
 }  // namespace date
+
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 
 #endif  // DATE_H

--- a/tz.cpp
+++ b/tz.cpp
@@ -3208,8 +3208,9 @@ locate_native_zone(const std::string& native_tz_name)
 
 #endif  // TZ_TEST && TIMEZONE_MAPPING
 
+
+}  // namespace date
+
 #ifdef __GNUC__
 # pragma GCC diagnostic pop
 #endif
-
-}  // namespace date

--- a/tz.cpp
+++ b/tz.cpp
@@ -141,14 +141,10 @@ static CONSTDATA char folder_delimiter = '/';
 
 #endif
 
-#ifdef __GNUC__
-// GCC complains about unused return from strerror_r
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-result"
 # if __GNUC__ < 5
-   // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
+// GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
+#  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
 #endif
 
 #ifdef _WIN32

--- a/tz.cpp
+++ b/tz.cpp
@@ -141,6 +141,16 @@ static CONSTDATA char folder_delimiter = '/';
 
 #endif
 
+#ifdef __GNUC__
+// GCC complains about unused return from strerror_r
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-result"
+# if __GNUC__ < 5
+   // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
+#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+#endif
+
 #ifdef _WIN32
 
 namespace
@@ -3100,12 +3110,6 @@ current_zone()
 
 #else // !WIN32
 
-#ifdef __GNUC__
-// GCC complains about unused return from strerror_r
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
-#endif
-
 const time_zone*
 current_zone()
 {
@@ -3183,10 +3187,6 @@ current_zone()
     throw std::runtime_error("Could not get current timezone");
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
-
 #endif // !WIN32
 
 #if defined(TZ_TEST) && defined(TIMEZONE_MAPPING)
@@ -3207,5 +3207,9 @@ locate_native_zone(const std::string& native_tz_name)
 }
 
 #endif  // TZ_TEST && TIMEZONE_MAPPING
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 }  // namespace date

--- a/tz.cpp
+++ b/tz.cpp
@@ -141,10 +141,10 @@ static CONSTDATA char folder_delimiter = '/';
 
 #endif
 
-# if __GNUC__ < 5
+#if __GNUC__ < 5
 // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #ifdef _WIN32
@@ -3207,6 +3207,6 @@ locate_native_zone(const std::string& native_tz_name)
 
 }  // namespace date
 
-#ifdef __GNUC__
+#if __GNUC__ < 5
 # pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Sorry to reopen this pull request from #141 I had to restart from a fresh repository (after a messup I was forced to delete the old repository). 

> If we're going to do this, I think I would rather just wrap all of date.h and tz.cpp with this. And tz.cpp doesn't need the pop. That way the code is easier to read (without all the clutter).

For the sake of lisibility, I have then wrapped all the pragma diagnostic at top and bottom of the files. The drawdown is that we could ignore some pedantic warnings now with GCC. Is that acceptable for you ?
