### PR TITLE
Fix -Wshadow for gcc and clang.

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -2280,9 +2280,9 @@ download_to_string(const std::string& url, std::string& str)
     curl_write_callback write_cb = [](char* contents, std::size_t size, std::size_t nmemb,
                                       void* userp) -> std::size_t
     {
-        auto& str = *static_cast<std::string*>(userp);
+        auto& userstr = *static_cast<std::string*>(userp);
         auto realsize = size * nmemb;
-        str.append(contents, realsize);
+        userstr.append(contents, realsize);
         return realsize;
     };
     curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, write_cb);

--- a/tz.h
+++ b/tz.h
@@ -141,25 +141,25 @@ private:
 template <class Duration>
 inline
 nonexistent_local_time::nonexistent_local_time(local_time<Duration> tp,
-                                               local_seconds first,
+                                               local_seconds begin,
                                                const std::string& first_abbrev,
-                                               local_seconds last,
+                                               local_seconds end,
                                                const std::string& last_abbrev,
                                                sys_seconds time_sys)
-    : std::runtime_error(make_msg(tp, first, first_abbrev, last, last_abbrev, time_sys))
+    : std::runtime_error(make_msg(tp, begin, first_abbrev, end, last_abbrev, time_sys))
     {}
 
 template <class Duration>
 std::string
-nonexistent_local_time::make_msg(local_time<Duration> tp, local_seconds first,
-                                 const std::string& first_abbrev, local_seconds last,
+nonexistent_local_time::make_msg(local_time<Duration> tp, local_seconds begin,
+                                 const std::string& first_abbrev, local_seconds end,
                                  const std::string& last_abbrev, sys_seconds time_sys)
 {
     using namespace date;
     std::ostringstream os;
     os << tp << " is in a gap between\n"
-       << first << ' ' << first_abbrev << " and\n"
-       << last  << ' ' << last_abbrev
+       << begin << ' ' << first_abbrev << " and\n"
+       << end   << ' ' << last_abbrev
        << " which are both equivalent to\n"
        << time_sys << " UTC";
     return os.str();


### PR DESCRIPTION
gcc-6.3.1-1.fc25.x86_64
```
date/tz.cpp: In lambda function:
date/tz.cpp:2283:15: error: declaration of ‘auto& str’ shadows a parameter [-Werror=shadow]
         auto& str = *static_cast<std::string*>(userp);
               ^~~
date/tz.cpp:2272:57: note: shadowed declaration is here
 download_to_string(const std::string& url, std::string& str)
                                                         ^~~
cc1plus: all warnings being treated as errors

```

clang-3.9.1-2.fc25.x86_64
```
./date/tz.h:146:62: error: declaration shadows a variable in namespace 'date::literals' [-Werror,-Wshadow]
                                               local_seconds last,
                                                             ^
./date/date.h:1684:27: note: previous declaration is here
CONSTDATA date::last_spec last{};
                          ^
./date/tz.h:155:81: error: declaration shadows a variable in namespace 'date::literals' [-Werror,-Wshadow]
                                 const std::string& first_abbrev, local_seconds last,
                                                                                ^
./date/date.h:1684:27: note: previous declaration is here
CONSTDATA date::last_spec last{};
                          ^
```