### PR TITLE
Fix gcc -O -D_FORTIFY_SOURCE.

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -3134,7 +3134,8 @@ current_zone()
         {
             std::ostringstream os;
             char message[128];
-            (void)strerror_r(errno, message, 128);
+            if (strerror_r(errno, message, sizeof(message)) != 0)
+                message[0] = '\0';
             os << "realpath failure: errno = " << errno << "; " << message;
             throw std::runtime_error(os.str());
         }


### PR DESCRIPTION
It is discussed whether it is a GCC bug or not but it is as it is.
gcc-6.3.1-1.fc25.x86_64
```
date/tz.cpp: In function ‘const date::time_zone* date::current_zone()’:
date/tz.cpp:3137:50: error: ignoring return value of ‘char* strerror_r(int, char*, size_t)’, declared with attribute warn_unused_result [-Werror=unused-result]
             (void)strerror_r(errno, message, 128);
                                                  ^
cc1plus: all warnings being treated as errors
```