### PR TITLE
Two error handling fixes (one fixing uninitialized stack memory being accessed)

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -2946,10 +2946,10 @@ current_zone()
         else
         {
             std::ostringstream os;
+            os << "realpath failure: errno = " << errno;
             char message[128];
-            if (strerror_r(errno, message, sizeof(message)) != 0)
-                message[0] = '\0';
-            os << "realpath failure: errno = " << errno << "; " << message;
+            if (strerror_r(errno, message, sizeof(message)) == 0)
+                os << "; " << message;
             throw std::runtime_error(os.str());
         }
 

--- a/tz.cpp
+++ b/tz.cpp
@@ -2946,9 +2946,7 @@ current_zone()
             result = string(rp);
         else
         {
-            throw runtime_error("realpath failure: errno = " +
-                                to_string(errno) + "; " +
-                                system_error(errno, system_category()).what());
+            throw system_error(errno, system_category(), "realpath() failed");
         }
 
         const char zonepath[] = "/usr/share/zoneinfo/";


### PR DESCRIPTION
c7bc7fe fixes the a message of a `std::runtime_error` containing a trailing semicolon and space character but no following error message if the related `strerror_r` call fails.

bd09561 fixes the incompatibility with the GNU C library where `strerror_r` is instead defined in an non-portable XSI-incompatible manner. I discovered this issue because of a compiler warning about comparing the return value of `strerror_r` (a pointer) to an integer `0` on GNU platforms. Regardless of the warning, the code still compiled, and resulted in uninitialized stack memory being read from the `message` buffer:

- Before c7bc7fe:
  - if the GNU-specific `strerror_r` succeeded, the `if (strerror_r(errno, message, sizeof(message)) != 0)` branch was taken, `message` was set to the empty string (regardless of whether `strerror_r` wrote to it) and later streamed to `os`. No undefined behavior resulted, but the actual error message was ignored.
  -  if the GNU-specific `strerror_r` failed and returned `nullptr`, the conditional would not trigger and the uninitialized `message` buffer was streamed to `os`.
- After c7bc7fe:
  - if the GNU-specific `strerror_r` succeeded, the `if (strerror_r(errno, message, sizeof(message)) == 0)` condition was not triggered and `message` was not streamed to `os`. No undefined behavior resulted, but the actual error message was ignored.
  -  if the GNU-specific `strerror_r` failed and returned `nullptr`, the conditional triggered the uninitialized `message` buffer was streamed to `os`.