### PR TITLE
fix compile warning about unused get_download_gz_file()

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -269,6 +269,7 @@ get_install()
     return ref;
 }
 
+#if HAS_REMOTE_API
 static
 std::string
 get_download_gz_file(const std::string& version)
@@ -276,6 +277,7 @@ get_download_gz_file(const std::string& version)
     auto file = get_install() + version + ".tar.gz";
     return file;
 }
+#endif  // HAS_REMOTE_API
 
 // These can be used to reduce the range of the database to save memory
 CONSTDATA auto min_year = date::year::min();


### PR DESCRIPTION
get_download_gz_file() is not used when HAS_REMOTE_API=0, and causes:

warning: 'std::__cxx11::string date::get_download_gz_file(const string&)' defined but not used [-Wunused-function]

Wrap get_download_gz_file() inside #ifdef to remove the warning.
