### PR TITLE
changes for compatibility with Clang with Microsoft CodeGen

### DIFF
--- a/date.h
+++ b/date.h
@@ -1069,7 +1069,7 @@ std::chrono::time_point<Clock, To>
 floor(const std::chrono::time_point<Clock, FromDuration>& tp)
 {
     using std::chrono::time_point;
-    return time_point<Clock, To>{floor<To>(tp.time_since_epoch())};
+    return time_point<Clock, To>{date::floor<To>(tp.time_since_epoch())};
 }
 
 // round to nearest, to even on tie
@@ -4156,7 +4156,7 @@ typename std::enable_if
 >::type
 operator<<(std::basic_ostream<CharT, Traits>& os, const sys_time<Duration>& tp)
 {
-    auto const dp = floor<days>(tp);
+    auto const dp = date::floor<days>(tp);
     return os << year_month_day(dp) << ' ' << make_time(tp-dp);
 }
 
@@ -4173,7 +4173,7 @@ inline
 std::basic_ostream<CharT, Traits>&
 operator<<(std::basic_ostream<CharT, Traits>& os, const local_time<Duration>& ut)
 {
-    return os << sys_time<Duration>{ut.time_since_epoch()};
+    return (os << sys_time<Duration>{ut.time_since_epoch()});
 }
 
 // to_stream
@@ -4951,7 +4951,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     throw std::runtime_error("Can not format %z with unknown offset");
                 auto m = duration_cast<minutes>(*offset_sec);
                 auto neg = m < minutes{0};
-                m = abs(m);
+                m = date::abs(m);
                 auto h = duration_cast<hours>(m);
                 m -= h;
                 if (neg)

--- a/tz.cpp
+++ b/tz.cpp
@@ -104,6 +104,11 @@
 
 #ifdef _WIN32
 #  include <io.h> // _unlink etc.
+
+#  if defined(__clang__)
+    struct IUnknown;    // fix for issue with static_cast<> in objbase.h (see https://github.com/philsquared/Catch/issues/690)
+#  endif
+
 #  include <ShlObj.h> // CoTaskFree, ShGetKnownFolderPath etc.
 #  if HAS_REMOTE_API
 #    include <direct.h> // _mkdir
@@ -654,7 +659,7 @@ detail::MonthDayTime::MonthDayTime(local_seconds tp, tz timezone)
     : zone_(timezone)
 {
     using namespace date;
-    const auto dp = floor<days>(tp);
+    const auto dp = date::floor<days>(tp);
     const auto hms = make_time(tp - dp);
     const auto ymd = year_month_day(dp);
     u = ymd.month() / ymd.day();
@@ -1827,14 +1832,14 @@ format_abbrev(std::string format, const std::string& variable, std::chrono::seco
                 }
                 else
                     temp = '+';
-                auto h = floor<hours>(off);
+                auto h = date::floor<hours>(off);
                 off -= h;
                 if (h < hours{10})
                     temp += '0';
                 temp += std::to_string(h.count());
                 if (off > seconds{0})
                 {
-                    auto m = floor<minutes>(off);
+                    auto m = date::floor<minutes>(off);
                     off -= m;
                     if (m < minutes{10})
                         temp += '0';
@@ -1891,7 +1896,7 @@ time_zone::get_info_impl(sys_seconds tp, int tz_int) const
     using namespace date;
     tz timezone = static_cast<tz>(tz_int);
     assert(timezone != tz::standard);
-    auto y = year_month_day(floor<days>(tp)).year();
+    auto y = year_month_day(date::floor<days>(tp)).year();
     if (y < min_year || y > max_year)
         throw std::runtime_error("The year " + std::to_string(static_cast<int>(y)) +
             " is out of range:[" + std::to_string(static_cast<int>(min_year)) + ", "

--- a/tz.h
+++ b/tz.h
@@ -448,7 +448,7 @@ sys_info
 time_zone::get_info(sys_time<Duration> st) const
 {
     using namespace std::chrono;
-    return get_info_impl(floor<seconds>(st));
+    return get_info_impl(date::floor<seconds>(st));
 }
 
 template <class Duration>
@@ -457,7 +457,7 @@ local_info
 time_zone::get_info(local_time<Duration> tp) const
 {
     using namespace std::chrono;
-    return get_info_impl(floor<seconds>(tp));
+    return get_info_impl(date::floor<seconds>(tp));
 }
 
 template <class Duration>


### PR DESCRIPTION
changes for compatibility with Clang on MSVC with Microsoft CodeGen (v140_clang_c2):

- added date:: namespace to flloor() and abs() calls
- added IUnknown forward declaration before including Windows headers to prevent issue with objbase.h (known issue with clang on MSVC)
- minor changes
