### PR TITLE
Also ignore leap-seconds.list

### DIFF
--- a/tz.cpp
+++ b/tz.cpp
@@ -2504,14 +2504,15 @@ init_tzdb()
         while ((d = readdir(dir)) != nullptr)
         {
             // Ignore these files:
-            if (d->d_name[0]                      == '.' || // curdir, prevdir, hidden
-                memcmp(d->d_name, "posix", 5)     == 0   || // starts with posix
-                strcmp(d->d_name, "Factory")      == 0   ||
-                strcmp(d->d_name, "iso3166.tab")  == 0   ||
-                strcmp(d->d_name, "right")        == 0   ||
-                strcmp(d->d_name, "+VERSION")     == 0   ||
-                strcmp(d->d_name, "zone.tab")     == 0   ||
-                strcmp(d->d_name, "zone1970.tab") == 0     )
+            if (d->d_name[0]                      == '.'    || // curdir, prevdir, hidden
+                memcmp(d->d_name, "posix", 5)     == 0      || // starts with posix
+                strcmp(d->d_name, "Factory")      == 0      ||
+                strcmp(d->d_name, "iso3166.tab")  == 0      ||
+                strcmp(d->d_name, "right")        == 0      ||
+                strcmp(d->d_name, "+VERSION")     == 0      ||
+                strcmp(d->d_name, "zone.tab")     == 0      ||
+                strcmp(d->d_name, "zone1970.tab") == 0      ||
+                strcmp(d->d_name, "leap-seconds.list") == 0   )
                 continue;
             auto subname = dirname + folder_delimiter + d->d_name;
             if(stat(subname.c_str(), &s) == 0)


### PR DESCRIPTION
The tzdata package on Ubuntu 16.04, maybe other distributions too, includes /usr/share/zoneinfo/leap-
seconds.list. This is not a TZif file, so it should be ignored.