### PR TITLE
Reformulate macros for static and shared linking on windows.

### DIFF
--- a/tz.h
+++ b/tz.h
@@ -128,10 +128,10 @@ static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,
 #ifdef _WIN32
 #  ifdef DATE_BUILD_DLL
 #    define DATE_API __declspec(dllexport)
-#  elif defined(DATE_BUILD_LIB)
-#    define DATE_API
-#  else
+#  elif defined(DATE_USE_DLL)
 #    define DATE_API __declspec(dllimport)
+#  else
+#    define DATE_API
 #  endif
 #else
 #  define DATE_API


### PR DESCRIPTION
(Upfront note: This patch will prevent some clients from linking to TZ as a shared library.
Those clients experiencing that will need to add the DATE_USED_SHARED=1 macro.
It's expected those clients will be relatively few compared to the statically linked users of TZ who should be able to remove the DATE_USE_LIB=1 macro from their project. Affects windows only currently.)

The existing formulation of macros for using tz as a static library or shared library is arguably not ideal.

Reasoning:
If you take use 3 from the USE CASE examples below, i.e. the 'compiling a client against the tz code as source code -the classic "drop tz into my project and go" path' one, using *the current* formulation of macros (i..e. before this patch), you will notice that you get different results on Linux from Windows. I think this is a convenience and consistency issue. i.e.:

g++ -o"validate.exe" -I.  test\tz_test\validate.cpp tz.cpp shell32.lib ole32.lib
On Linux, the above works with no macros:

But the same command on Windows:
cl -Fe"validate.exe" -EHsc -I.  test\tz_test\validate.cpp tz.cpp shell32.lib ole32.lib
will fail with compile/link errors unless DATE_BUILD_LIB=1 is also supplied.

That's arguably a bit inconsistent.

Unless DATE_BUILD_LIB=1 is supplied, the client assumes tz is going to be linked in as shared library, so it defines DATE_API as __declspec(dllimport) but when that api is found statically instead of dynamically, it generates a load of compile/link errors.

This patch makes these two cases work the same on both platforms. i.e. date always assumes you are going to be statically linking unless you specify otherwise.
So DATE_BUILD_LIB=x becomes obsolete, but DATE_USE_DLL is new and should be used if you plan to link to date as a shared library i.e. use a tz.dll. To build tz.dll itself you define DATE_BUILD_DLL=1 which is what I think tz expects today so there is no change for that use case.

Notice how the first 3 command lines below are all simplified by not needing DATE_BUILD_LIB=1 as they would without this patch, as they are all static linking use cases. This does come at the expense of one use case 5 becoming more complicated by needing DATE_BUILD_DLL=1, which would not be needed without this patch as that was the old default.

Below shows how the new formulation of macros work like this for the various use cases.
The command lines are for MSVC / Visual Studio.

# USE CASE 1: Package the tz code into a static library for linking into an app later.
cl -EHsc -I. -c -EHsc tz.cpp -Fo"tz.obj"
lib/out:libtz.lib tz.obj

# USE CASE 2: Compile a client and links against the tz static library.
cl -EHsc -I. -Fe"validate.exe" -EHsc test\tz_test\validate.cpp libtz.lib shell32.lib ole32.lib

# USE CASE 3. Compile a client against the tz code as source code -the classic "drop tz into my project and go" path.
cl -Fe"validate.exe" -EHsc -I. -EHsc test\tz_test\validate.cpp tz.cpp shell32.lib ole32.lib

# USE CASE 4: Package the tz code into a dynamic library so it can be found at runtime.
cl -DDATE_BUILD_DLL=1 -LD -EHsc -I. -Fe"tz.dll" -EHsc tz.cpp shell32.lib ole32.lib /link /implib:"tz.lib"

# USE CASE 5: Compile a client that expects to call tz as a dynamic library.
cl -Fe"validate.exe" -DDATE_USE_SHARED=1 -EHsc -I. -EHsc test\tz_test\validate.cpp tz.lib shell32.lib ole32.lib

# To be clear:
# In the examples tzlib.lib is a static library linked into the client. It's not an import library.
# tz.lib is an import library linked into the client. It's not a static library.
# tz.dll is the dynamic library that will be found at runtime. It's implicitly linked to via tz.lib which calls tz.dll.
# Note it's common to name both import and static libraries as tz.lib or something, but these examples avoid doing that for clarity. There generally is no standard here though as I believe Boost and mingw seems to use the convention adopted here, which I find clearer.

This reformulation means that DATE_BUILD_LIB is never needed and that's probably the majority of the use cases. 

This patch does not affect Linux as shared linking. This patch may be useful for some discussion of that too.

If this patch is accepted, perhaps these use cases and command lines could feature in the tz documentation. I could perhaps update the comments about DATE_API to reflect this a little too.
