### PR TITLE
Fix CHAR_BIT not found on GCC 6.3.0

### DIFF
--- a/date.h
+++ b/date.h
@@ -40,6 +40,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
+#include <climits>
 #include <ios>
 #include <istream>
 #include <iterator>
@@ -4665,10 +4666,10 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                         auto d = static_cast<int>(static_cast<unsigned>(fds.ymd.day()));
                         if (d < 10)
                             os << ' ';
-                        os << d << ' ' 
+                        os << d << ' '
                            << make_time(duration_cast<seconds>(fds.tod.to_duration()))
                            << ' ' << fds.ymd.year();
-                        
+
                     }
                     else  // *fmt == 'x'
                     {


### PR DESCRIPTION
Building with GCC 6.3.0 fails on date.h line 1046 because the CHAR_BIT macros isn't found. It appears that limits.h is included in the headers of some implementations, but not GCC 6.3.0. The fix is simply include climits (of limits.h if you prefer).