### PR TITLE
Fix uninitialized variable use in to_stream()

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -4566,7 +4566,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
 {
     using namespace std;
     using namespace std::chrono;
-    tm tm;
+    tm tm{};
 #if !ONLY_C_LOCALE
     auto& facet = use_facet<time_put<CharT>>(os.getloc());
 #endif


### PR DESCRIPTION
tm variable is not initialized in to_stream(), and valgrind warns about
"Conditional jump or move depends on uninitialised value(s)".

Initialize tm to zero, and with that done, we can drop tm
initializations from two particular code paths.