### PR TITLE
Replacing 0 with nullptr to avoid GCC warning

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -5963,7 +5963,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 {
 #if !ONLY_C_LOCALE
                     ios_base::iostate err = ios_base::goodbit;
-                    f.get(is, 0, is, err, &tm, command, fmt+1);
+                    f.get(is, nullptr, is, err, &tm, command, fmt+1);
                     if ((err & ios::failbit) == 0)
                         wd = tm.tm_wday;
                     is.setstate(err);
@@ -5987,7 +5987,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 {
 #if !ONLY_C_LOCALE
                     ios_base::iostate err = ios_base::goodbit;
-                    f.get(is, 0, is, err, &tm, command, fmt+1);
+                    f.get(is, nullptr, is, err, &tm, command, fmt+1);
                     if ((err & ios::failbit) == 0)
                         m = tm.tm_mon + 1;
                     is.setstate(err);
@@ -6009,7 +6009,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 {
 #if !ONLY_C_LOCALE
                     ios_base::iostate err = ios_base::goodbit;
-                    f.get(is, 0, is, err, &tm, command, fmt+1);
+                    f.get(is, nullptr, is, err, &tm, command, fmt+1);
                     if ((err & ios::failbit) == 0)
                     {
                         Y = tm.tm_year + 1900;
@@ -6064,7 +6064,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 {
 #if !ONLY_C_LOCALE
                     ios_base::iostate err = ios_base::goodbit;
-                    f.get(is, 0, is, err, &tm, command, fmt+1);
+                    f.get(is, nullptr, is, err, &tm, command, fmt+1);
                     if ((err & ios::failbit) == 0)
                     {
                         Y = tm.tm_year + 1900;
@@ -6088,7 +6088,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 {
 #if !ONLY_C_LOCALE
                     ios_base::iostate err = ios_base::goodbit;
-                    f.get(is, 0, is, err, &tm, command, fmt+1);
+                    f.get(is, nullptr, is, err, &tm, command, fmt+1);
                     if ((err & ios::failbit) == 0)
                     {
                         h = hours{tm.tm_hour};
@@ -6131,7 +6131,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                         {
                             auto tY = tm.tm_year + 1900;
@@ -6190,7 +6190,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         command = nullptr;
                         width = -1;
                         modified = CharT{};
@@ -6224,7 +6224,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                             h = hours{tm.tm_hour};
                         is.setstate(err);
@@ -6294,7 +6294,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                             min = minutes{tm.tm_min};
                         is.setstate(err);
@@ -6320,7 +6320,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                             m = tm.tm_mon + 1;
                         is.setstate(err);
@@ -6375,7 +6375,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                         tm = std::tm{};
                         tm.tm_hour = I;
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if (err & ios::failbit)
                             goto broken;
                         h = hours{tm.tm_hour};
@@ -6413,7 +6413,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 {
 #if !ONLY_C_LOCALE
                     ios_base::iostate err = ios_base::goodbit;
-                    f.get(is, 0, is, err, &tm, command, fmt+1);
+                    f.get(is, nullptr, is, err, &tm, command, fmt+1);
                     if ((err & ios::failbit) == 0)
                     {
                         h = hours{tm.tm_hour};
@@ -6495,7 +6495,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                             s = duration_cast<Duration>(seconds{tm.tm_sec});
                         is.setstate(err);
@@ -6549,7 +6549,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else if (modified == CharT{'E'})
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                             Y = tm.tm_year + 1900;
                         is.setstate(err);
@@ -6575,7 +6575,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                             Y = tm.tm_year + 1900;
                         is.setstate(err);
@@ -6679,7 +6679,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, 0, is, err, &tm, command, fmt+1);
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
                         if ((err & ios::failbit) == 0)
                             wd = tm.tm_wday;
                         is.setstate(err);


### PR DESCRIPTION
All the calls to `std::time_get::get` had `0` as end-of-range iterator.

E.g.

```
auto& f = use_facet<time_get<CharT>>(is.getloc());
// ...
f.get(is, 0, is, err, &tm, command, fmt+1);
```

Using `nullptr` instead of `0` doesn't trigger the GCC 5.x warning:

> warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]