### PR TITLE
Add a workaround for a missing operator<< for gcc 5 on linux.

### DIFF
--- a/include/date/tz_private.h
+++ b/include/date/tz_private.h
@@ -291,6 +291,7 @@ struct transition
     {
         using namespace date;
         using namespace std::chrono;
+        using date::operator<<;
         os << t.timepoint << "Z ";
         if (t.info->offset >= seconds{0})
             os << '+';


### PR DESCRIPTION
This is a fix for build error on ubuntu 16.04 with gcc 5.4 in case when os provided timezone database is used. See issue #205 for details.