### PR TITLE
still some patches to build on Windows with clang in MSVC

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -1098,7 +1098,7 @@ trunc(const std::chrono::duration<Rep, Period>& d)
 }
 
 #ifndef HAS_CHRONO_ROUNDING
-#  if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+#  if defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 190023918 || (_MSC_FULL_VER >= 190000000 && defined (__clang__)))
 #    define HAS_CHRONO_ROUNDING 1
 #  elif defined(__cpp_lib_chrono) && __cplusplus > 201402 && __cpp_lib_chrono >= 201510
 #    define HAS_CHRONO_ROUNDING 1

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2434,7 +2434,7 @@ time_zone::get_info_impl(sys_seconds tp, int tz_int) const
     using namespace date;
     tz timezone = static_cast<tz>(tz_int);
     assert(timezone != tz::standard);
-    auto y = year_month_day(date::floor<days>(tp)).year();
+    auto y = year_month_day(floor<days>(tp)).year();
     if (y < min_year || y > max_year)
         throw std::runtime_error("The year " + std::to_string(static_cast<int>(y)) +
             " is out of range:[" + std::to_string(static_cast<int>(min_year)) + ", "


### PR DESCRIPTION
date:: scope added to several floor<>() and round<>() calls to build on Windows with MSVC v140_clang_c2 and LLVM-vs2014.

This kind of problem only arises when instantiating template functions, therefore I am not sure if there are further calls that may need date:: scope...
