### PR TITLE
Implementation of clock_cast function.

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -156,6 +156,8 @@ using months = std::chrono::duration
 
 // time_point
 
+using sys_clock = std::chrono::system_clock;
+
 template <class Duration>
     using sys_time = std::chrono::time_point<std::chrono::system_clock, Duration>;
 

--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -1836,6 +1836,16 @@ public:
     static CONSTDATA bool is_steady = false;
 
     static time_point now();
+
+    template<typename Duration>
+    static 
+    std::chrono::time_point<sys_clock, typename std::common_type<Duration, std::chrono::seconds>::type>
+    to_sys(const std::chrono::time_point<utc_clock, Duration>&);
+
+    template<typename Duration>
+    static
+    std::chrono::time_point<utc_clock, typename std::common_type<Duration, std::chrono::seconds>::type>
+    from_sys(const std::chrono::time_point<sys_clock, Duration>&);
 };
 
 template <class Duration>
@@ -1844,9 +1854,8 @@ template <class Duration>
 using utc_seconds = utc_time<std::chrono::seconds>;
 
 template <class Duration>
-inline
 utc_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_utc_time(const sys_time<Duration>& st)
+utc_clock::from_sys(const sys_time<Duration>& st)
 {
     using namespace std::chrono;
     using duration = typename std::common_type<Duration, seconds>::type;
@@ -1885,9 +1894,8 @@ is_leap_second(date::utc_time<Duration> const& ut)
 }
 
 template <class Duration>
-inline
 sys_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_sys_time(const utc_time<Duration>& ut)
+utc_clock::to_sys(const utc_time<Duration>& ut)
 {
     using namespace std::chrono;
     using duration = typename std::common_type<Duration, seconds>::type;
@@ -1903,7 +1911,7 @@ utc_clock::time_point
 utc_clock::now()
 {
     using namespace std::chrono;
-    return to_utc_time(system_clock::now());
+    return from_sys(system_clock::now());
 }
 
 template <class CharT, class Traits, class Duration>
@@ -1979,6 +1987,16 @@ public:
     static const bool is_steady     = false;
 
     static time_point now() NOEXCEPT;
+
+    template<typename Duration>
+    static 
+    std::chrono::time_point<utc_clock, typename std::common_type<Duration, std::chrono::seconds>::type>
+    to_utc(const std::chrono::time_point<tai_clock, Duration>&) NOEXCEPT;
+
+    template<typename Duration>
+    static
+    std::chrono::time_point<tai_clock, typename std::common_type<Duration, std::chrono::seconds>::type>
+    from_utc(const std::chrono::time_point<utc_clock, Duration>&) NOEXCEPT;
 };
 
 template <class Duration>
@@ -1989,7 +2007,7 @@ using tai_seconds = tai_time<std::chrono::seconds>;
 template <class Duration>
 inline
 utc_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_utc_time(const tai_time<Duration>& t) NOEXCEPT
+tai_clock::to_utc(const tai_time<Duration>& t) NOEXCEPT
 {
     using namespace std::chrono;
     using duration = typename std::common_type<Duration, seconds>::type;
@@ -2000,7 +2018,7 @@ to_utc_time(const tai_time<Duration>& t) NOEXCEPT
 template <class Duration>
 inline
 tai_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_tai_time(const utc_time<Duration>& t) NOEXCEPT
+tai_clock::from_utc(const utc_time<Duration>& t) NOEXCEPT
 {
     using namespace std::chrono;
     using duration = typename std::common_type<Duration, seconds>::type;
@@ -2008,20 +2026,12 @@ to_tai_time(const utc_time<Duration>& t) NOEXCEPT
             (sys_days(year{1970}/jan/1) - sys_days(year{1958}/jan/1) + seconds{10});
 }
 
-template <class Duration>
-inline
-tai_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_tai_time(const sys_time<Duration>& t)
-{
-    return to_tai_time(to_utc_time(t));
-}
-
 inline
 tai_clock::time_point
 tai_clock::now() NOEXCEPT
 {
     using namespace std::chrono;
-    return to_tai_time(system_clock::now());
+    return from_utc(utc_clock::now());
 }
 
 template <class CharT, class Traits, class Duration>
@@ -2087,6 +2097,17 @@ public:
     static const bool is_steady     = false;
 
     static time_point now() NOEXCEPT;
+
+    template<typename Duration>
+    static 
+    std::chrono::time_point<utc_clock, typename std::common_type<Duration, std::chrono::seconds>::type>
+    to_utc(const std::chrono::time_point<gps_clock, Duration>&) NOEXCEPT;
+
+    template<typename Duration>
+    static
+    std::chrono::time_point<gps_clock, typename std::common_type<Duration, std::chrono::seconds>::type>
+    from_utc(const std::chrono::time_point<utc_clock, Duration>&) NOEXCEPT;
+
 };
 
 template <class Duration>
@@ -2097,7 +2118,7 @@ using gps_seconds = gps_time<std::chrono::seconds>;
 template <class Duration>
 inline
 utc_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_utc_time(const gps_time<Duration>& t) NOEXCEPT
+gps_clock::to_utc(const gps_time<Duration>& t) NOEXCEPT
 {
     using namespace std::chrono;
     using duration = typename std::common_type<Duration, seconds>::type;
@@ -2108,7 +2129,7 @@ to_utc_time(const gps_time<Duration>& t) NOEXCEPT
 template <class Duration>
 inline
 gps_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_gps_time(const utc_time<Duration>& t)
+gps_clock::from_utc(const utc_time<Duration>& t) NOEXCEPT
 {
     using namespace std::chrono;
     using duration = typename std::common_type<Duration, seconds>::type;
@@ -2116,20 +2137,12 @@ to_gps_time(const utc_time<Duration>& t)
             (sys_days(year{1980}/jan/sun[1]) - sys_days(year{1970}/jan/1) + seconds{9});
 }
 
-template <class Duration>
-inline
-gps_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_gps_time(const sys_time<Duration>& t)
-{
-    return to_gps_time(to_utc_time(t));
-}
-
 inline
 gps_clock::time_point
 gps_clock::now() NOEXCEPT
 {
     using namespace std::chrono;
-    return to_gps_time(system_clock::now());
+    return from_utc(utc_clock::now());
 }
 
 template <class CharT, class Traits, class Duration>
@@ -2183,42 +2196,224 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
     return is;
 }
 
-template <class Duration>
-inline
-sys_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_sys_time(const tai_time<Duration>& t)
+template<typename SourceClock, typename DestClock>
+struct clock_time_conversion
+{};
+
+template<>
+struct clock_time_conversion<sys_clock, sys_clock>
 {
-    return to_sys_time(to_utc_time(t));
+  template <class Duration>
+  auto operator()(const std::chrono::time_point<sys_clock, Duration>& st)
+    -> std::chrono::time_point<sys_clock, Duration>
+  { 
+    return st;
+  }
+};
+
+template<>
+struct clock_time_conversion<utc_clock, utc_clock>
+{
+  template <class Duration>
+  auto operator()(const std::chrono::time_point<utc_clock, Duration>& st)
+    -> std::chrono::time_point<utc_clock, Duration>
+  { 
+    return st;
+  }
+};
+
+template<>
+struct clock_time_conversion<sys_clock, utc_clock>
+{
+  template <class Duration>
+  utc_time<typename std::common_type<Duration, std::chrono::seconds>::type>
+  operator()(const sys_time<Duration>& st) const
+  {
+     return utc_clock::from_sys(st);
+  }
+};
+
+template<>
+struct clock_time_conversion<utc_clock, sys_clock>
+{
+  template <class Duration>
+  sys_time<typename std::common_type<Duration, std::chrono::seconds>::type>
+  operator()(const utc_time<Duration>& ut) const
+  {
+    return utc_clock::to_sys(ut);
+  }
+};
+
+template<typename Clock>
+struct clock_time_conversion<Clock, Clock>
+{
+  template <class Duration>
+  auto operator()(const std::chrono::time_point<Clock, Duration>& st)
+    -> std::chrono::time_point<Clock, Duration>
+  { 
+    return st;
+  }
+};
+
+namespace ctc_detail
+{
+  //Check if TimePoint is time for given clock, 
+  //if so exposes it as type typedef
+  template<typename Clock, typename TimePoint>
+  struct return_clock_time
+    : std::enable_if<
+        std::is_same<Clock, typename TimePoint::clock>::value,
+        TimePoint
+      >
+  {};
+
+  // Check if Clock has to_sys method accepting TimePoint with given duration const& and returning sys_time
+  // If so has nested type member equal to return type to_sys.
+  template<typename Clock, typename Duration, typename = void>
+  struct return_to_sys 
+  {};
+
+  template<typename Clock, typename Duration>
+  struct return_to_sys<Clock, Duration, decltype(Clock::to_sys(std::declval<std::chrono::time_point<Clock, Duration> const&>()), void())>
+    : return_clock_time<sys_clock, typename std::decay<decltype(Clock::to_sys(std::declval<std::chrono::time_point<Clock, Duration> const&>()))>::type>
+  {};
+
+  // Similiar to above
+  template<typename Clock, typename Duration, typename = void>
+  struct return_from_sys 
+  {};
+
+  template<typename Clock, typename Duration>
+  struct return_from_sys<Clock, Duration, decltype(Clock::from_sys(std::declval<std::chrono::time_point<sys_clock, Duration> const&>()), void())>
+    : return_clock_time<Clock, typename std::decay<decltype(Clock::from_sys(std::declval<std::chrono::time_point<sys_clock, Duration> const&>()))>::type>
+  {};
+
+  // Similiar to above
+  template<typename Clock, typename Duration, typename = void>
+  struct return_to_utc 
+  {};
+
+  template<typename Clock, typename Duration>
+  struct return_to_utc<Clock, Duration, decltype(Clock::to_utc(std::declval<std::chrono::time_point<Clock, Duration> const&>()), void())>
+    : return_clock_time<utc_clock, typename std::decay<decltype(Clock::to_utc(std::declval<std::chrono::time_point<Clock, Duration> const&>()))>::type>
+  {};
+
+  // Similiar to above
+  template<typename Clock, typename Duration, typename = void>
+  struct return_from_utc 
+  {};
+
+  template<typename Clock, typename Duration>
+  struct return_from_utc<Clock, Duration, decltype(Clock::from_utc(std::declval<std::chrono::time_point<utc_clock, Duration> const&>()), void())>
+    : return_clock_time<Clock, typename std::decay<decltype(Clock::from_utc(std::declval<std::chrono::time_point<utc_clock, Duration> const&>()))>::type>
+  {};
 }
 
-template <class Duration>
-inline
-sys_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_sys_time(const gps_time<Duration>& t)
+template<typename SourceClock>
+struct clock_time_conversion<SourceClock, sys_clock> 
 {
-    return to_sys_time(to_utc_time(t));
+  template <class Duration>
+  auto operator()(const std::chrono::time_point<SourceClock, Duration>& st)
+    -> typename ctc_detail::return_to_sys<SourceClock, Duration>::type
+  {
+    return SourceClock::to_sys(st);
+  }
+};
+
+template<typename DestClock>
+struct clock_time_conversion<sys_clock, DestClock>
+{
+  template <class Duration>
+  auto operator()(const std::chrono::time_point<sys_clock, Duration>& st)
+    -> typename ctc_detail::return_from_sys<DestClock, Duration>::type
+  {
+    return DestClock::from_sys(st);
+  }
+};
+
+template<typename SourceClock>
+struct clock_time_conversion<SourceClock, utc_clock> 
+{
+  template <class Duration>
+  auto operator()(const std::chrono::time_point<SourceClock, Duration>& st)
+    -> typename ctc_detail::return_to_utc<SourceClock, Duration>::type
+  {
+    return SourceClock::to_utc(st);
+  }
+};
+
+template<typename DestClock>
+struct clock_time_conversion<utc_clock, DestClock>
+{
+  template <class Duration>
+  auto operator()(const std::chrono::time_point<utc_clock, Duration>& ut)
+    -> typename ctc_detail::return_from_utc<DestClock, Duration>::type
+  {
+    return DestClock::from_utc(ut);
+  }
+};
+
+namespace clock_cast_detail
+{
+   template<typename DestClock, typename SourceClock, typename Duration>
+   auto conv_clock(const std::chrono::time_point<SourceClock, Duration>& st)
+     -> decltype(std::declval<clock_time_conversion<SourceClock, DestClock>&>()(st))
+   {
+     clock_time_conversion<SourceClock, DestClock> converter;
+     return converter(st);
+   }
+
+   //direct triat conversion, 2nd candidate 
+   template<typename DestClock, typename SourceClock, typename Duration>
+   auto cc_impl(const std::chrono::time_point<SourceClock, Duration>& st,
+                const std::chrono::time_point<SourceClock, Duration>* /* 1st */)
+     -> decltype(conv_clock<DestClock>(st))
+   {
+     return conv_clock<DestClock>(st);
+   }
+
+   //conversion trought sys, 3rd candidate
+   template<typename DestClock, typename SourceClock, typename Duration>
+   auto cc_impl(const std::chrono::time_point<SourceClock, Duration>& st,
+                const void* /* 2nd */)
+     -> decltype(conv_clock<DestClock>(conv_clock<sys_clock>(st)))
+   {
+     return conv_clock<DestClock>(conv_clock<sys_clock>(st));
+   }
+
+   //conversion trought utc, 3rd candidate
+   template<typename DestClock, typename SourceClock, typename Duration>
+   auto cc_impl(const std::chrono::time_point<SourceClock, Duration>& st,
+                const void* /* 2nd */)
+     -> decltype(conv_clock<DestClock>(conv_clock<utc_clock>(st)))
+   {
+     return conv_clock<DestClock>(conv_clock<utc_clock>(st));
+   }
+
+   //conversion trought sys and utc, 4th candidate
+   template<typename DestClock, typename SourceClock, typename Duration>
+   auto cc_impl(const std::chrono::time_point<SourceClock, Duration>& st,
+                ... /* 3rd */)
+     -> decltype(conv_clock<DestClock>(conv_clock<utc_clock>(conv_clock<sys_clock>(st))))
+   {
+     return conv_clock<DestClock>(conv_clock<utc_clock>(conv_clock<sys_clock>(st)));
+   }
+
+   //conversion trought utc and sys, 4th candidate
+   template<typename DestClock, typename SourceClock, typename Duration>
+   auto cc_impl(const std::chrono::time_point<SourceClock, Duration>& st,
+                ... /* 3rd */)
+     -> decltype(conv_clock<DestClock>(conv_clock<sys_clock>(conv_clock<utc_clock>(st))))
+   {
+     return conv_clock<DestClock>(conv_clock<sys_clock>(conv_clock<utc_clock>(st)));
+   }
 }
 
-template <class Duration>
-inline
-tai_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_tai_time(const gps_time<Duration>& t) NOEXCEPT
-{
-    using namespace std::chrono;
-    using duration = typename std::common_type<Duration, seconds>::type;
-    return tai_time<duration>{t.time_since_epoch()} +
-            (sys_days(year{1980}/jan/sun[1]) - sys_days(year{1958}/jan/1) + seconds{19});
-}
-
-template <class Duration>
-inline
-gps_time<typename std::common_type<Duration, std::chrono::seconds>::type>
-to_gps_time(const tai_time<Duration>& t) NOEXCEPT
-{
-    using namespace std::chrono;
-    using duration = typename std::common_type<Duration, seconds>::type;
-    return gps_time<duration>{t.time_since_epoch()} -
-            (sys_days(year{1980}/jan/sun[1]) - sys_days(year{1958}/jan/1) + seconds{19});
+template<typename DestClock, typename SourceClock, typename Duration>
+auto clock_cast(const std::chrono::time_point<SourceClock, Duration>& st)
+ -> decltype(clock_cast_detail::cc_impl<DestClock>(st, &st))
+{ 
+  return clock_cast_detail::cc_impl<DestClock>(st, &st); 
 }
 
 #endif  // !MISSING_LEAP_SECONDS

--- a/test/tz_test/clock_cast.pass.cpp
+++ b/test/tz_test/clock_cast.pass.cpp
@@ -1,0 +1,101 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Tomasz Kamiiński
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "tz.h"
+#include <cassert>
+
+int
+main()
+{
+    using namespace date;
+
+    // self
+    {
+       sys_days st(1997_y/dec/12);
+       auto ut = utc_clock::from_sys(st);
+       auto tt = tai_clock::from_utc(ut);
+       
+       assert(clock_cast<sys_clock>(st) == st);
+       assert(clock_cast<utc_clock>(ut) == ut);
+       assert(clock_cast<tai_clock>(tt) == tt);
+    }
+
+    // sys <-> utc
+    {
+       sys_days st(1997_y/dec/12);
+       auto ut = utc_clock::from_sys(st);
+
+       assert(clock_cast<utc_clock>(st) == ut);
+       assert(clock_cast<sys_clock>(ut) == st);      
+    }
+
+    // tai <-> utc
+    {
+       sys_days st(1997_y/dec/12);
+       auto ut = utc_clock::from_sys(st);
+       auto tt = tai_clock::from_utc(ut);
+
+       assert(clock_cast<tai_clock>(ut) == tt);
+       assert(clock_cast<utc_clock>(tt) == ut);
+    }
+
+    // tai <-> sys
+    {
+       sys_days st(1997_y/dec/12);
+       auto ut = utc_clock::from_sys(st);
+       auto tt = tai_clock::from_utc(ut);
+
+       assert(clock_cast<tai_clock>(st) == tt);
+       assert(clock_cast<sys_clock>(tt) == st);
+    }
+
+    // gps <-> utc
+    {
+       sys_days st(1997_y/dec/12);
+       auto ut = utc_clock::from_sys(st);
+       auto gt = gps_clock::from_utc(ut);
+
+       assert(clock_cast<gps_clock>(ut) == gt);
+       assert(clock_cast<utc_clock>(gt) == ut);
+    }
+
+    // gps <-> sys
+    {
+       sys_days st(1997_y/dec/12);
+       auto ut = utc_clock::from_sys(st);
+       auto gt = gps_clock::from_utc(ut);
+
+       assert(clock_cast<gps_clock>(st) == gt);
+       assert(clock_cast<sys_clock>(gt) == st);
+    }
+
+    // tai <-> gps   
+    {
+       sys_days st(1997_y/dec/12);
+       auto ut = utc_clock::from_sys(st);
+       auto tt = tai_clock::from_utc(ut);
+       auto gt = gps_clock::from_utc(ut);
+
+       assert(clock_cast<gps_clock>(tt) == gt);
+       assert(clock_cast<tai_clock>(gt) == tt);
+    }
+}

--- a/test/tz_test/custom_clock_casts.pass.cpp
+++ b/test/tz_test/custom_clock_casts.pass.cpp
@@ -1,0 +1,186 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Tomasz Kamiiński
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "tz.h"
+#include <cassert>
+#include <type_traits>
+
+//used to count number of conversion
+int conversions = 0;
+
+//to/from impl
+struct mil_clock
+{
+  using duration = std::common_type_t<date::sys_clock::duration, date::days>;
+  using rep = duration::rep;
+  using period = duration::period;
+  using time_point = std::chrono::time_point<mil_clock, duration>;
+
+  static constexpr date::sys_days epoch = date::year{2000}/date::month{0}/date::day{1};
+
+  template<typename Duration>
+  static
+  date::sys_time<std::common_type_t<Duration, date::days>> 
+  to_sys(std::chrono::time_point<mil_clock, Duration> const& tp)
+  {
+    ++conversions;
+    return epoch + tp.time_since_epoch();
+  }
+
+  template<typename Duration>
+  static
+  std::chrono::time_point<mil_clock, std::common_type_t<Duration, date::days>>
+  from_sys(std::chrono::time_point<date::sys_clock, Duration> const& tp)
+  {
+    ++conversions;
+    using res = std::chrono::time_point<mil_clock, std::common_type_t<Duration, date::days>>;
+    return res(tp - epoch);
+  }
+
+  static time_point now()
+  {
+    return from_sys(date::sys_clock::now());
+  }
+};
+
+
+date::sys_days const mil_clock::epoch;
+
+// traits example
+struct s2s_clock 
+{
+  using duration = date::sys_clock::duration;
+  using rep = duration::rep;
+  using period = duration::period;
+  using time_point = std::chrono::time_point<s2s_clock, duration>;
+
+  template<typename Duration>
+  static
+  std::chrono::time_point<date::sys_clock, Duration> 
+  to_sys(std::chrono::time_point<s2s_clock, Duration> const& tp)
+  {
+    ++conversions;
+    return std::chrono::time_point<date::sys_clock, Duration>(tp.time_since_epoch());
+  }
+
+  template<typename Duration>
+  static
+  std::chrono::time_point<s2s_clock, Duration> 
+  from_sys(std::chrono::time_point<date::sys_clock, Duration> const& tp)
+  {
+    ++conversions;
+    return std::chrono::time_point<s2s_clock, Duration>(tp.time_since_epoch());
+  }
+
+  static time_point now()
+  {
+    return from_sys(date::sys_clock::now());
+  }
+};
+
+namespace date
+{
+   template<>
+   struct clock_time_conversion<s2s_clock, mil_clock>
+   {
+     template<typename Duration>
+     std::chrono::time_point<mil_clock, std::common_type_t<Duration, date::days>>
+     operator()(std::chrono::time_point<s2s_clock, Duration> const& tp)
+     {
+       ++conversions;
+       using res = std::chrono::time_point<mil_clock, std::common_type_t<Duration, date::days>>;
+       return res(tp.time_since_epoch() - mil_clock::epoch.time_since_epoch());
+     }
+   };
+}
+
+int
+main()
+{
+    using namespace date;
+
+    // self
+    {
+       sys_days st(1997_y/dec/12);
+       auto mt = mil_clock::from_sys(st);
+       
+       assert(clock_cast<mil_clock>(mt) == mt);
+    }
+
+    // mil <-> sys
+    {
+       sys_days st(1997_y/dec/12);
+       auto mt = mil_clock::from_sys(st);
+
+       assert(clock_cast<mil_clock>(st) == mt);
+       assert(clock_cast<sys_clock>(mt) == st);      
+    }
+
+    // mil <-> utc
+    {
+       sys_days st(1997_y/dec/12);
+       auto mt = mil_clock::from_sys(st);
+       auto ut = utc_clock::from_sys(st);
+
+       assert(clock_cast<mil_clock>(ut) == mt);
+       assert(clock_cast<utc_clock>(mt) == ut);      
+    }
+
+    // mil <-> tai
+    {
+       sys_days st(1997_y/dec/12);
+       auto mt = mil_clock::from_sys(st);
+       auto ut = utc_clock::from_sys(st);
+       auto tt = tai_clock::from_utc(ut);
+
+       assert(clock_cast<tai_clock>(mt) == tt);
+       assert(clock_cast<mil_clock>(tt) == mt);
+    }
+
+    // mil <-> gps
+    {
+       sys_days st(1997_y/dec/12);
+       auto mt = mil_clock::from_sys(st);
+       auto ut = utc_clock::from_sys(st);
+       auto gt = gps_clock::from_utc(ut);
+
+       assert(clock_cast<gps_clock>(mt) == gt);
+       assert(clock_cast<mil_clock>(gt) == mt);
+    }
+
+    // s2s -> mil
+    {
+       sys_days st(1997_y/dec/12);
+       auto mt = mil_clock::from_sys(st);
+       auto s2t = s2s_clock::from_sys(st);
+
+       //direct trait conversion
+       conversions = 0;
+       assert(clock_cast<mil_clock>(s2t) == mt);
+       assert(conversions == 1);
+
+       //uses sys_clock       
+       conversions = 0;
+       assert(clock_cast<s2s_clock>(mt) == s2t);
+       assert(conversions == 2);
+    }
+}

--- a/test/tz_test/noncatsable_clock_casts.pass.cpp
+++ b/test/tz_test/noncatsable_clock_casts.pass.cpp
@@ -1,0 +1,246 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Tomasz Kamiiński
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "tz.h"
+#include <type_traits>
+#include <cassert>
+
+template<typename SourceClock, typename DestClock, typename = void>
+struct is_clock_castable 
+  : std::false_type
+{};
+
+template<typename SourceClock, typename DestClock>
+struct is_clock_castable<SourceClock, DestClock, decltype(date::clock_cast<DestClock>(typename SourceClock::time_point()), void())>
+  : std::true_type
+{};
+
+
+//Clock based on steady clock, not related to wall time (sys_clock/utc_clock)
+struct steady_based_clock 
+{
+  using duration = std::chrono::steady_clock::duration;
+  using rep = duration::rep;
+  using period = duration::period;
+  using time_point = std::chrono::time_point<steady_based_clock, duration>;
+
+  static time_point now()
+  {
+    return time_point(std::chrono::steady_clock::now().time_since_epoch());
+  }
+};
+
+//Traits that allow conversion between steady_clock and steady_based clock
+//Does not use wall-time clocks as rally (sys/utc)
+namespace date
+{
+   template<>
+   struct clock_time_conversion<steady_based_clock, std::chrono::steady_clock>
+   {
+     template<typename Duration>
+     std::chrono::time_point<std::chrono::steady_clock, Duration>
+     operator()(std::chrono::time_point<steady_based_clock, Duration> const& tp) const
+     {
+       using res = std::chrono::time_point<std::chrono::steady_clock, Duration>;
+       return res(tp.time_since_epoch());
+     }
+   };
+
+   template<>
+   struct clock_time_conversion<std::chrono::steady_clock, steady_based_clock>
+   {
+     template<typename Duration>
+     std::chrono::time_point<steady_based_clock, Duration>
+     operator()(std::chrono::time_point<std::chrono::steady_clock, Duration> const& tp) const
+     {
+       using res = std::chrono::time_point<steady_based_clock, Duration>;
+       return res(tp.time_since_epoch());
+     }
+   };
+}
+
+//Ambigous clocks both providing to/from_sys and to/from_utc 
+//They are mock_ups just returning zero time_point
+struct amb1_clock
+{
+   using duration = std::chrono::seconds;
+   using rep = duration::rep;
+   using period = duration::period;
+   using time_point = std::chrono::time_point<amb1_clock>;
+
+   static time_point now() 
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<date::sys_clock, Duration>
+   to_sys(std::chrono::time_point<amb1_clock, Duration> const&)
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<amb1_clock, Duration>
+   from_sys(std::chrono::time_point<date::sys_clock, Duration> const&)
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<date::utc_clock, Duration>
+   to_utc(std::chrono::time_point<amb1_clock, Duration> const&)
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<amb1_clock, Duration>
+   from_utc(std::chrono::time_point<date::utc_clock, Duration> const&)
+   {
+     return {};
+   }
+};
+
+struct amb2_clock
+{
+   using duration = std::chrono::seconds;
+   using rep = duration::rep;
+   using period = duration::period;
+   using time_point = std::chrono::time_point<amb2_clock>;
+
+   static time_point now() 
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<date::sys_clock, Duration>
+   to_sys(std::chrono::time_point<amb2_clock, Duration> const&)
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<amb2_clock, Duration>
+   from_sys(std::chrono::time_point<date::sys_clock, Duration> const&)
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<date::utc_clock, Duration>
+   to_utc(std::chrono::time_point<amb2_clock, Duration> const&)
+   {
+     return {};
+   }
+
+   template<typename Duration>
+   static
+   std::chrono::time_point<amb2_clock, Duration>
+   from_utc(std::chrono::time_point<date::utc_clock, Duration> const&)
+   {
+     return {};
+   }
+};
+
+namespace date
+{
+   //Disambiguates that sys_clock is preffered
+   template<>
+   struct clock_time_conversion<amb2_clock, amb1_clock>
+   {
+     template<typename Duration>
+     std::chrono::time_point<amb1_clock, Duration>
+     operator()(std::chrono::time_point<amb2_clock, Duration> const& tp) const
+     {
+       return amb1_clock::from_sys(amb2_clock::to_sys(tp));
+     }
+   };
+}
+
+int
+main()
+{
+    using namespace date;
+    using namespace std::chrono;
+
+    //steady_clock (must be different that sys_clock)
+    static_assert(is_clock_castable<steady_clock, steady_clock>::value, "steady_clock -> steady_clock");
+    static_assert(!is_clock_castable<steady_clock, sys_clock>::value, "steady_clock -> sys_clock");
+    static_assert(!is_clock_castable<sys_clock, steady_clock>::value, "sys_clock -> steady_clock");
+    static_assert(!is_clock_castable<steady_clock, utc_clock>::value, "steady_clock -> utc_clock");
+    static_assert(!is_clock_castable<utc_clock, steady_clock>::value, "utc_clock -> steady_clock");
+    static_assert(!is_clock_castable<steady_clock, tai_clock>::value, "steady_clock -> tai_clock");
+    static_assert(!is_clock_castable<tai_clock, steady_clock>::value, "tai_clock -> steady_clock");
+
+    //steady_based_clock (unrelated to sys_clock and utc_clocks)
+    static_assert(is_clock_castable<steady_based_clock, steady_based_clock>::value, "steady_based_clock -> steady_based_clock");
+    static_assert(!is_clock_castable<steady_based_clock, sys_clock>::value, "steady_based_clock -> sys_clock");
+    static_assert(!is_clock_castable<sys_clock, steady_based_clock>::value, "sys_clock -> steady_based_clock");
+    static_assert(!is_clock_castable<steady_based_clock, utc_clock>::value, "steady_based_clock -> utc_clock");
+    static_assert(!is_clock_castable<utc_clock, steady_based_clock>::value, "utc_clock -> steady_based_clock");
+    static_assert(!is_clock_castable<steady_based_clock, tai_clock>::value, "steady_based_clock -> tai_clock");
+    static_assert(!is_clock_castable<tai_clock, steady_based_clock>::value, "tai_clock -> steady_based_clock");
+
+    //steady_based <-> steady_clock
+    {
+      auto s1 = steady_clock::time_point(steady_clock::duration(200));
+      auto s2 = steady_based_clock::time_point(steady_based_clock::duration(200));
+   
+      assert(clock_cast<steady_based_clock>(s1) == s2);
+      assert(clock_cast<steady_clock>(s2) == s1);
+    }
+
+    //ambX <-> sys/utc works as one rally can be used in each case, or one lead to quicker conversione
+    static_assert(is_clock_castable<amb1_clock, amb1_clock>::value, "amb1_clock -> amb1_clock");
+    static_assert(is_clock_castable<amb1_clock, sys_clock>::value, "amb1_clock -> sys_clock");
+    static_assert(is_clock_castable<sys_clock, amb1_clock>::value, "sys_clock -> amb1_clock");
+    static_assert(is_clock_castable<amb1_clock, utc_clock>::value, "amb1_clock -> utc_clock");
+    static_assert(is_clock_castable<utc_clock, amb1_clock>::value, "utc_clock -> amb1_clock");
+    static_assert(is_clock_castable<amb1_clock, tai_clock>::value, "amb1_clock -> tai_clock");
+    static_assert(is_clock_castable<tai_clock, amb1_clock>::value, "tai_clock -> amb1_clock");
+    static_assert(is_clock_castable<amb1_clock, tai_clock>::value, "amb1_clock -> tai_clock");
+    static_assert(is_clock_castable<gps_clock, amb1_clock>::value, "gps_clock -> amb1_clock");
+    static_assert(is_clock_castable<amb2_clock, amb2_clock>::value, "amb2_clock -> amb2_clock");
+    static_assert(is_clock_castable<amb2_clock, sys_clock>::value, "amb2_clock -> sys_clock");
+    static_assert(is_clock_castable<sys_clock, amb2_clock>::value, "sys_clock -> amb2_clock");
+    static_assert(is_clock_castable<amb2_clock, utc_clock>::value, "amb2_clock -> utc_clock");
+    static_assert(is_clock_castable<utc_clock, amb2_clock>::value, "utc_clock -> amb2_clock");
+    static_assert(is_clock_castable<amb2_clock, tai_clock>::value, "amb2_clock -> tai_clock");
+    static_assert(is_clock_castable<tai_clock, amb2_clock>::value, "tai_clock -> amb2_clock");
+    static_assert(is_clock_castable<amb2_clock, tai_clock>::value, "amb2_clock -> tai_clock");
+    static_assert(is_clock_castable<gps_clock, amb2_clock>::value, "gps_clock -> amb2_clock");
+
+    //amb1 -> amb2: ambigous because can either go trough sys_clock or utc_clock
+    static_assert(!is_clock_castable<amb1_clock, amb2_clock>::value, "amb1_clock -> amb2_clock");
+
+    //amb2 -> amb1: disambiguated via trait specialization
+    static_assert(is_clock_castable<amb2_clock, amb1_clock>::value, "amb2_clock -> amb1_clock");
+}


### PR DESCRIPTION
Added implementation of ``clock_cast`` function that replaced existing ``to_clock__time`` family of functions. See commits comment for more details.