### PR TITLE
Fix iOS build

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -86,6 +86,10 @@
 #include "date/tz_private.h"
 #include "date/ios.h"
 
+#ifndef __APPLE__
+#    define TARGET_OS_IPHONE 0
+#endif
+
 #if USE_OS_TZDB
 #  include <dirent.h>
 #endif
@@ -333,6 +337,9 @@ discover_tz_dir()
     else
         throw runtime_error("discover_tz_dir failed to find zoneinfo\n");
 #  else  // __APPLE__
+#      if TARGET_OS_IPHONE
+    return "/var/db/timezone/zoneinfo";
+#      else
     CONSTDATA auto timezone = "/etc/localtime";
     if (!(lstat(timezone, &sb) == 0 && S_ISLNK(sb.st_mode) && sb.st_size > 0))
         throw runtime_error("discover_tz_dir failed\n");
@@ -349,6 +356,7 @@ discover_tz_dir()
     if (i == string::npos)
         throw runtime_error("discover_tz_dir failed to find '/'\n");
     return result.substr(0, i);
+#      endif
 #  endif  // __APPLE__
 }
 


### PR DESCRIPTION
The directory detection code for Mac introduced in 22a229af9106c032949f9a87a9a4fd9cc667a1ee makes us crash on iOS - this fixes the iOS version.

Note that we can't check #ifdef TARGET_OS_IPHONE here but have to do #if TARGET_OS_IPHONE because on Mac this value is defined and set to 0.