### PR TITLE
rename and mark-as-advanced cmake-variable used in print_option function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,9 @@ option( USE_TZ_DB_IN_DOT "Save the timezone database in the current folder" OFF 
 option( BUILD_TZ_STATIC  "Build a static version of library" ON )
 
 function( print_option OPT )
-	if ( NOT DEFINED CURR_${OPT} OR ( NOT CURR_${OPT} STREQUAL ${OPT} ) )
-		set( CURR_${OPT} ${${OPT}} CACHE BOOL "" )
+	if ( NOT DEFINED PRINT_OPTION_CURR_${OPT} OR ( NOT PRINT_OPTION_CURR_${OPT} STREQUAL ${OPT} ) )
+		set( PRINT_OPTION_CURR_${OPT} ${${OPT}} CACHE BOOL "" )
+		mark_as_advanced(PRINT_OPTION_CURR_${OPT})
 		message( "# date: ${OPT} ${${OPT}}" )
 	endif( )
 endfunction( )


### PR DESCRIPTION
To have a nicer CMake experience, some cmake-variable "pollution" (introduced by me -- sorry), can be improved:
Cmake-variables that have global visibility, but are **only** relevant within function `print_option` are now marked as advanced.

Thus the following CMake-variables are now marked as advanced, and only visible in `cmake-gui`, if "advanced" is clicked:
```cmake
 PRINT_OPTION_CURR_BUILD_TZ_STATIC
 PRINT_OPTION_CURR_USE_SYSTEM_TZ_DB
 PRINT_OPTION_CURR_USE_TZ_DB_IN_DOT
```

Normally "advanced" is not clicked, and you then you'll have a nice short listing, where the above-mentioned variables are not shown (their only relevant to internal "bookkeeping" of function `print_option`).