### PR TITLE
Add Travis file and add some fixes for libc++

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if [[ ${CC} == "clang" ]]; then
+    CMAKE_FLAGS='-DCMAKE_CXX_FLAGS=-stdlib=libc++'
+fi
+
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${CMAKE_FLAGS}
+make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+script: ./.travis.sh


### PR DESCRIPTION
Despite these fixes the library still doesn't compile in Clang, which is why the clang job is
allowed to fail.