### PR TITLE
Export a CMake config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,14 @@ target_include_directories(date_interface INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 
+if(WIN32 AND NOT CYGWIN)
+    set(DEF_INSTALL_CMAKE_DIR CMake)
+else()
+    set(DEF_INSTALL_CMAKE_DIR lib/cmake/date)
+endif()
 
 install( TARGETS date_interface EXPORT DateConfig )
-install( EXPORT DateConfig DESTINATION lib/cmake/date )
+install( EXPORT DateConfig DESTINATION ${DEF_INSTALL_CMAKE_DIR} )
 install( TARGETS tz DESTINATION lib )
 install( DIRECTORY ${HEADER_FOLDER}/ DESTINATION include/ )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,16 +85,12 @@ add_library(date_interface INTERFACE) # an interface (not a library), to enable 
 
 # add include folders to the INTERFACE and targets that consume it
 target_include_directories(date_interface INTERFACE
-    $<BUILD_INTERFACE:
-        ${CMAKE_CURRENT_SOURCE_DIR}/${HEADER_FOLDER}
-    >
-    $<INSTALL_INTERFACE:
-        include
-    >
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    $<INSTALL_INTERFACE:include>
 )
 
 
-install( TARGETS date_prj EXPORT DateConfig )
+install( TARGETS date_interface EXPORT DateConfig )
 install( EXPORT DateConfig DESTINATION lib/cmake/date )
 install( TARGETS tz DESTINATION lib )
 install( DIRECTORY ${HEADER_FOLDER}/ DESTINATION include/ )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ target_include_directories(date_interface INTERFACE
 )
 
 
+install( TARGETS date_prj EXPORT DateConfig )
+install( EXPORT DateConfig DESTINATION lib/cmake/date )
 install( TARGETS tz DESTINATION lib )
 install( DIRECTORY ${HEADER_FOLDER}/ DESTINATION include/ )
 


### PR DESCRIPTION
This will allow users to import the project via CMake methods, i.e `find_package` rather than doing it manually.