### PR TITLE
bump msvc define to fix compile issue on MSVC 15.6

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -2197,7 +2197,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
     return is;
 }
 
-#if !defined(_MSC_VER) || _MSC_VER > 1912
+#if !defined(_MSC_VER) || _MSC_VER > 1913
 
 // clock_time_conversion
 
@@ -2471,7 +2471,7 @@ clock_cast(const std::chrono::time_point<SrcClock, Duration>& tp)
     return clock_cast_detail::cc_impl<DstClock>(tp, &tp);
 }
 
-#endif  // !defined(_MSC_VER) || _MSC_VER > 1912
+#endif  // !defined(_MSC_VER) || _MSC_VER > 1913
 
 // Deprecated API
 


### PR DESCRIPTION
With MSVC 2017 (15.6 Preview 2) they bumped the compiler version to 1913 but did not fix the underlying issue which our ifdef tries to workaround. I will check again when 15.6 is released, but wanted to give a heads up that we might need to bump the ifdef version we check on.