### PR TITLE
Fix VS compilation when there is a `string` type in the global scope

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -5788,7 +5788,7 @@ read_long_double(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned
     unsigned count = 0;
     auto decimal_point = Traits::to_int_type(
         use_facet<numpunct<CharT>>(is.getloc()).decimal_point());
-    string buf;
+    std::string buf;
     while (true)
     {
         auto ic = is.peek();


### PR DESCRIPTION
I'm introducing the date library to a legacy codebase. It has defined `string` class (other than `std::string`) in a global scope, making the date header to fail to compile.

The following:
```
struct string {}; 
#include <date/date.h>
``` 

fails to compile VS 2017.5 with `error C2872: 'string': ambiguous symbol`.

I fixed that by explicitly qualifing the `std::string` usage with `std` namespace. 
I see there are other symbols which might suffer from the same issue (like `numpunct`) but for now I fixed the one that stopped me from using the library.