### PR TITLE
Fix case of generated dateConfig so it will work on a case sensitive …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,8 @@ else()
     set(DEF_INSTALL_CMAKE_DIR lib/cmake/date)
 endif()
 
-install( TARGETS date_interface EXPORT DateConfig )
-install( EXPORT DateConfig DESTINATION ${DEF_INSTALL_CMAKE_DIR} )
+install( TARGETS date_interface EXPORT dateConfig )
+install( EXPORT dateConfig DESTINATION ${DEF_INSTALL_CMAKE_DIR} )
 install( TARGETS tz DESTINATION lib )
 install( DIRECTORY ${HEADER_FOLDER}/ DESTINATION include/ )
 


### PR DESCRIPTION
Fix case of generated dateConfig so it will work on a case sensitive filesystem.

This way it will work with cmake find_package on Linux.