### PR TITLE
isspace, isalnum are undefined for signed chars?

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -6855,7 +6855,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 }
                 else  // !command
                 {
-                    if (isspace(*fmt))
+                    if (isspace(static_cast<unsigned char>(*fmt)))
                         ws(is); // space matches 0 or more white space characters
                     else
                         read(is, *fmt);


### PR DESCRIPTION
Full disclosure: I'm not that confident in my change, as I never really worked with those functions (especially I've no idea what happens if use wide chars as inputs?).

http://en.cppreference.com/w/cpp/string/byte/isspace says:
> the behavior of std::isspace is undefined if the argument's value is neither representable as unsigned char nor equal to EOF. To use these functions safely with plain chars (or signed chars), the argument should first be converted to unsigned char

I noticed this when using from_stream with a format string which contained utf8 characters under VisualStudio2017 which raised a debug assertion.