### PR TITLE
Add a configuration header (issue #313)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,35 +40,44 @@ set( HEADER_FILES
 	${HEADER_FOLDER}/date/tz_private.h
 )
 
-if( BUILD_TZ_STATIC )
-	add_library( tz STATIC ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
-else( )
-	add_library( tz SHARED ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
-endif( )
-
 if( USE_SYSTEM_TZ_DB )
-	target_compile_definitions( tz PRIVATE -DUSE_AUTOLOAD=0 )
-	target_compile_definitions( tz PRIVATE -DHAS_REMOTE_API=0 )
+	set(AUTO_DOWNLOAD 0)
+	set(HAS_REMOTE_API 0)
+
 	# cannot set USE_OS_TZDB to 1 on Windows
 	if( NOT WIN32 )
-		target_compile_definitions( tz PUBLIC -DUSE_OS_TZDB=1 )
+		set(USE_OS_TZDB 1)
+	else ( )
+		set(USE_OS_TZDB 0)
 	endif( )
 else( )
-	target_compile_definitions( tz PRIVATE -DUSE_AUTOLOAD=1 )
-	target_compile_definitions( tz PRIVATE -DHAS_REMOTE_API=1 )
-	target_compile_definitions( tz PUBLIC -DUSE_OS_TZDB=0 )
+	set(AUTO_DOWNLOAD 1)
+	set(HAS_REMOTE_API 1)
+	set(USE_OS_TZDB 0)
+
 	find_package( CURL REQUIRED )
 	include_directories( SYSTEM ${CURL_INCLUDE_DIRS} )
 	set( OPTIONAL_LIBRARIES ${CURL_LIBRARIES} )
+endif( )
+
+if( NOT TZ_CXX_STANDARD )
+	set( TZ_CXX_STANDARD 17 )
+endif( )
+
+set(TZ_CONFIG_H_PATH ${CMAKE_CURRENT_BINARY_DIR}/${HEADER_FOLDER}/date/tz_config.h)
+configure_file(tz_config.h.in ${TZ_CONFIG_H_PATH} @ONLY)
+
+
+if( BUILD_TZ_STATIC )
+	add_library( tz STATIC ${HEADER_FILES} ${TZ_CONFIG_H_PATH} ${SOURCE_FOLDER}/tz.cpp )
+else( )
+	add_library( tz SHARED ${HEADER_FILES} ${TZ_CONFIG_H_PATH} ${SOURCE_FOLDER}/tz.cpp )
 endif( )
 
 if( USE_TZ_DB_IN_DOT )
 	target_compile_definitions( tz PRIVATE -DINSTALL=. )
 endif( )
 
-if( NOT TZ_CXX_STANDARD )
-    set( TZ_CXX_STANDARD 17 )
-endif( )
 
 set_property(TARGET tz PROPERTY CXX_STANDARD ${TZ_CXX_STANDARD})
 target_link_libraries( tz ${CMAKE_THREAD_LIBS_INIT} ${OPTIONAL_LIBRARIES} )
@@ -77,6 +86,7 @@ target_link_libraries( tz ${CMAKE_THREAD_LIBS_INIT} ${OPTIONAL_LIBRARIES} )
 target_include_directories(tz PUBLIC
     $<BUILD_INTERFACE:
         ${CMAKE_CURRENT_SOURCE_DIR}/${HEADER_FOLDER}
+        ${CMAKE_CURRENT_BINARY_DIR}/${HEADER_FOLDER} # For the configuration header
     >
     $<INSTALL_INTERFACE:
         include
@@ -104,6 +114,7 @@ install( TARGETS tz
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})  # This is for Windows
 install( DIRECTORY ${HEADER_FOLDER}/ DESTINATION include/ )
+install( FILES ${TZ_CONFIG_H_PATH} DESTINATION include/date/ )
 
 if ( ENABLE_DATE_TESTING )
 
@@ -148,7 +159,7 @@ if ( ENABLE_DATE_TESTING )
             #target_compile_definitions( ${BIN_NAME} PRIVATE ${TST_NAME} )
             set( TEST_BIN_NAME ${CMAKE_BINARY_DIR}/${BIN_NAME} )
             add_custom_target( ${BIN_NAME}
-                COMMAND ${PROJECT_SOURCE_DIR}/compile_fail.sh ${TEST_BIN_NAME} ${CMAKE_CXX_COMPILER} -std=c++14 -L${CMAKE_BINARY_DIR}/ -ltz -I${PROJECT_SOURCE_DIR}/${HEADER_FOLDER}/date -o ${BIN_NAME} ${TEST_FILE}
+                COMMAND ${PROJECT_SOURCE_DIR}/compile_fail.sh ${TEST_BIN_NAME} ${CMAKE_CXX_COMPILER} -std=c++14 -L${CMAKE_BINARY_DIR}/ -ltz -I${PROJECT_SOURCE_DIR}/${HEADER_FOLDER}/date -I${CMAKE_BINARY_DIR}/${HEADER_FOLDER}/date -o ${BIN_NAME} ${TEST_FILE}
                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                 COMMENT ${TST_NAME}
                 )

--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -43,20 +43,18 @@
 // required. On Windows, the names are never "Standard" so mapping is always required.
 // Technically any OS may use the mapping process but currently only Windows does use it.
 
+#include "tz_config.h"
+
 #ifndef USE_OS_TZDB
-#  define USE_OS_TZDB 0
+#  error "Missing define expected from configuration header"
 #endif
 
 #ifndef HAS_REMOTE_API
-#  if USE_OS_TZDB == 0
-#    ifdef _WIN32
-#      define HAS_REMOTE_API 0
-#    else
-#      define HAS_REMOTE_API 1
-#    endif
-#  else  // HAS_REMOTE_API makes no since when using the OS timezone database
-#    define HAS_REMOTE_API 0
-#  endif
+#  error "Missing define expected from configuration header"
+#endif
+
+#ifndef AUTO_DOWNLOAD
+#  error "Missing define expected from configuration header"
 #endif
 
 #ifdef __clang__
@@ -69,10 +67,6 @@ static_assert(!(USE_OS_TZDB && HAS_REMOTE_API),
 
 #ifdef __clang__
 # pragma clang diagnostic pop
-#endif
-
-#ifndef AUTO_DOWNLOAD
-#  define AUTO_DOWNLOAD HAS_REMOTE_API
 #endif
 
 static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,

--- a/tz_config.h.in
+++ b/tz_config.h.in
@@ -1,0 +1,9 @@
+#ifndef TZ_CONFIG_H
+#define TZ_CONFIG_H
+
+#cmakedefine01 USE_OS_TZDB
+#cmakedefine01 HAS_REMOTE_API
+#cmakedefine01 AUTO_DOWNLOAD
+#cmakedefine TZ_CXX_STANDARD @TZ_CXX_STANDARD@
+
+#endif // TZ_CONFIG_H


### PR DESCRIPTION
This makes it easier to install and use the tz library correctly,
since the correct defines, which were used when tz was compiled
will be set by the configuration header which is automatically
included by tz.h

This follows the pattern set by common open source libraries like
libpng and freetype.

This commit also fixes a bug where the define USE_AUTOLOAD changed
name to AUTO_DOWNLOAD but the cmake was not updated correspondingly.

This was caught because we added

at the top of the tz.h header after we include the configuration
header.