### PR TITLE
Standardise CMake files (BUILD_SHARED_LIBS and CMAKE_CXX_STANDARD)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
-cmake_minimum_required( VERSION 3.0.2 )
+cmake_minimum_required( VERSION 3.1.0 )
 
 project( date_prj )
 
 include( GNUInstallDirs )
 
 find_package( Threads REQUIRED )
+
+# Override by setting on CMake command line.
+set( CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are requested.")
 
 option( USE_SYSTEM_TZ_DB "Use the operating system's timezone database" OFF )
 option( USE_TZ_DB_IN_DOT "Save the timezone database in the current folder" OFF )
@@ -66,11 +69,6 @@ if( USE_TZ_DB_IN_DOT )
 	target_compile_definitions( tz PRIVATE -DINSTALL=. )
 endif( )
 
-if( NOT TZ_CXX_STANDARD )
-    set( TZ_CXX_STANDARD 17 )
-endif( )
-
-set_property(TARGET tz PROPERTY CXX_STANDARD ${TZ_CXX_STANDARD})
 target_link_libraries( tz ${CMAKE_THREAD_LIBS_INIT} ${OPTIONAL_LIBRARIES} )
 
 # add include folders to the library and targets that consume it
@@ -124,7 +122,6 @@ if ( ENABLE_DATE_TESTING )
                 set( BIN_NAME ${PREFIX}_bin )
                 set( TST_NAME ${PREFIX}_test )
                 add_executable( ${BIN_NAME} EXCLUDE_FROM_ALL ${TEST_FILE} )
-                set_property(TARGET ${BIN_NAME} PROPERTY CXX_STANDARD ${TZ_CXX_STANDARD})
                 add_test( ${TST_NAME} ${BIN_NAME} )
                 target_link_libraries( ${BIN_NAME} tz )
                 add_dependencies( testit ${BIN_NAME} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set( CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are req
 
 option( USE_SYSTEM_TZ_DB "Use the operating system's timezone database" OFF )
 option( USE_TZ_DB_IN_DOT "Save the timezone database in the current folder" OFF )
-option( BUILD_TZ_STATIC  "Build a static version of library" ON )
+option( BUILD_SHARED_LIBS  "Build a shared version of library" OFF )
 option( ENABLE_DATE_TESTING "Enable unit tests" ON )
 
 function( print_option OPT )
@@ -24,7 +24,7 @@ endfunction( )
 
 print_option( USE_SYSTEM_TZ_DB )
 print_option( USE_TZ_DB_IN_DOT )
-print_option( BUILD_TZ_STATIC  )
+print_option( BUILD_SHARED_LIBS  )
 print_option( ENABLE_DATE_TESTING )
 
 set( HEADER_FOLDER "include" )
@@ -43,11 +43,7 @@ set( HEADER_FILES
 	${HEADER_FOLDER}/date/tz_private.h
 )
 
-if( BUILD_TZ_STATIC )
-	add_library( tz STATIC ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
-else( )
-	add_library( tz SHARED ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
-endif( )
+add_library( tz ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
 
 if( USE_SYSTEM_TZ_DB )
 	target_compile_definitions( tz PRIVATE -DUSE_AUTOLOAD=0 )


### PR DESCRIPTION
There were a couple of features of the CMake build system in `date` that can be easily replaced with more "CMakey" `CMake`. There are more things to do but these ones seemed to be very clean mappings.

Feel free to reject this for backwards compat reasons (people would have to change the options they use with CMake).