### PR TITLE
Add string_view support for Visual Studio 2017

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -31,7 +31,7 @@
 // We did not mean to shout.
 
 #ifndef HAS_STRING_VIEW
-#  if __cplusplus >= 201703
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #    define HAS_STRING_VIEW 1
 #  else
 #    define HAS_STRING_VIEW 0

--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -1441,7 +1441,7 @@ zoned_time<Duration, TimeZonePtr>::zoned_time(TimeZonePtr z,
 #if HAS_STRING_VIEW
 
 template <class Duration, class TimeZonePtr>
-template <class, class>
+template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
                                               const sys_time<Duration>& st)
@@ -1449,7 +1449,7 @@ zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
     {}
 
 template <class Duration, class TimeZonePtr>
-template <class, class>
+template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
                                               const local_time<Duration>& t)
@@ -1457,7 +1457,7 @@ zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
     {}
 
 template <class Duration, class TimeZonePtr>
-template <class, class>
+template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
                                               const local_time<Duration>& t, choose c)
@@ -1465,14 +1465,14 @@ zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
     {}
 
 template <class Duration, class TimeZonePtr>
-template <class, class>
+template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name, const zoned_time& zt)
     : zoned_time(zoned_traits<TimeZonePtr>::locate_zone(name), zt)
     {}
 
 template <class Duration, class TimeZonePtr>
-template <class, class>
+template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
                                               const zoned_time& zt, choose c)

--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -1366,7 +1366,7 @@ zoned_time<Duration, TimeZonePtr>::zoned_time(TimeZonePtr z)
 #if HAS_STRING_VIEW
 
 template <class Duration, class TimeZonePtr>
-template <class, class>
+template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name)
     : zoned_time(zoned_traits<TimeZonePtr>::locate_zone(name))


### PR DESCRIPTION
Here is a small patch that adds `string_view` support for Visual Studio 2017. It should make future [vcpkg](https://github.com/Microsoft/vcpkg) integration easier.

Some tests in the `testit` CMake target failed, but they seem to have nothing to do with my changes:

```
13 - date_test_pass_range_test (Failed)
32 - date_test_pass_parse_test (Failed)
44 - date_test_pass_year_month_test (Failed)
45 - date_test_pass_year_month_day_test (Failed)
46 - date_test_pass_year_month_day_last_test (Failed)
47 - date_test_pass_year_month_weekday_test (Failed)
48 - date_test_pass_year_month_weekday_last_test (Failed)
61 - tz_test_pass_validate_test (Failed)
```