### PR TITLE
fixed build with latest VS2017 (v15.7.1); also made usable in WinRT mode, where some file IO API are not available

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -103,7 +103,7 @@ namespace date
 #    define CONSTCD11 constexpr
 #    define CONSTCD14 constexpr
 #    define NOEXCEPT noexcept
-#    define NOEXCEPT_COND(...) noexcept(__VA_ARGS__)
+#    define NOEXCEPT_COND(...) /*noexcept(__VA_ARGS__)*/
 #  endif
 
 #elif defined(__SUNPRO_CC) && __SUNPRO_CC <= 0x5150

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -117,6 +117,14 @@
 // gcc/mingw supports unistd.h on Win32 but MSVC does not.
 
 #ifdef _WIN32
+#  ifdef WINAPI_FAMILY
+#    include <winapifamily.h>
+#    if WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP
+#      define WINRT
+#      define INSTALL .
+#    endif
+#  endif
+
 #  include <io.h> // _unlink etc.
 
 #  if defined(__clang__)
@@ -173,6 +181,7 @@ static CONSTDATA char folder_delimiter = '/';
 #if !USE_OS_TZDB
 
 #  ifdef _WIN32
+#    ifndef WINRT
 
 namespace
 {
@@ -212,6 +221,7 @@ get_download_folder()
     return get_known_folder(FOLDERID_Downloads);
 }
 
+#    endif // WINRT
 #  else // !_WIN32
 
 #    if !defined(INSTALL) || HAS_REMOTE_API


### PR DESCRIPTION
1. seems that VS2017 is not so good in constexpr evaluation inside 'noexcept(<expr>) '
2. WinRT restricts access to filesystem, but with minor modification library can use tzdata packaged inside WinRT application