### PR TITLE
Eliminate use of uninitialized offset.

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -7313,8 +7313,8 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                 fds.wd = weekday{static_cast<unsigned>(wd)};
             if (abbrev != nullptr)
                 *abbrev = std::move(temp_abbrev);
-            if (offset != nullptr)
-                *offset = temp_offset;
+            if (offset != nullptr && temp_offset != not_a_offset)
+              *offset = temp_offset;
         }
        return is;
     }


### PR DESCRIPTION
Parsing of dates in format "2018-05-25T09:22:38.684811653Z" is broken. This date is parsed to 1805429794651672965 nanoseconds which is equivalent to GMT: Friday, March 19, 2027 4:16:34 AM

Reference code:
std::string strDate = "2018-05-25T09:22:38.684811653Z";
std::istringstream in{ strDate };

date::sys_time<std::chrono::nanoseconds> tp;
in >> date::parse("%FT%TZ", tp);