### PR TITLE
Remove usage of octal literals from test

### DIFF
--- a/test/clock_cast_test/local_t.pass.cpp
+++ b/test/clock_cast_test/local_t.pass.cpp
@@ -9,13 +9,13 @@ main()
 
    // self
    {
-     auto ls = local_days{1970_y/01/01_d};
+     auto ls = local_days{1970_y/January/1_d};
      assert(clock_cast<local_t>(ls) == ls);
    }
 
    /// sys epoch
    {
-     auto ls = local_days{1970_y/01/01_d};
+     auto ls = local_days{1970_y/January/1_d};
      auto st = clock_cast<system_clock>(ls);
      assert(clock_cast<local_t>(st) == ls);
      assert(st.time_since_epoch() == seconds(0));
@@ -23,7 +23,7 @@ main()
 
    /// sys 2000 case
    {
-     auto ls = local_days{2000_y/01/01_d};
+     auto ls = local_days{2000_y/January/1_d};
      auto st = clock_cast<system_clock>(ls);
      assert(clock_cast<local_t>(st) == ls);
      assert(st.time_since_epoch() == seconds(946684800));
@@ -31,7 +31,7 @@ main()
 
    /// utc epoch
    {
-     auto lu = local_days{1970_y/01/01_d};
+     auto lu = local_days{1970_y/January/1_d};
      auto ut = clock_cast<utc_clock>(lu);
      assert(clock_cast<local_t>(ut) == lu);
      assert(ut.time_since_epoch() == seconds(0));
@@ -39,7 +39,7 @@ main()
 
    // utc leap second
    {
-     auto lu = local_days{2015_y/07/01_d} - milliseconds(1);
+     auto lu = local_days{2January5_y/07/1_d} - milliseconds(1);
      auto ut = clock_cast<utc_clock>(lu) + milliseconds(50); //into leap second
 
      assert(clock_cast<local_t>(ut) == lu);
@@ -47,7 +47,7 @@ main()
 
    /// utc paper example
    {
-     auto lu = local_days{2000_y/01/01_d};
+     auto lu = local_days{2000_y/January/1_d};
      auto ut = clock_cast<utc_clock>(lu);
      assert(clock_cast<local_t>(ut) == lu);
      assert(ut.time_since_epoch() == seconds(946684822));
@@ -55,54 +55,54 @@ main()
 
    /// tai epoch
    {
-     auto lt = local_days{1958_y/01/01_d};
+     auto lt = local_days{1958_y/January/1_d};
      auto tt = clock_cast<tai_clock>(lt);
      assert(clock_cast<local_t>(tt) == lt);
      assert(tt.time_since_epoch() == seconds(0));
 
-     auto lu = local_days{1958_y/01/01_d} - seconds(10);
+     auto lu = local_days{1958_y/January/1_d} - seconds(10);
      auto ut = clock_cast<utc_clock>(lu);
      assert(clock_cast<tai_clock>(ut) == tt);
    }
 
    // tai paper example
    {
-      auto lt = local_days{2000_y/01/01_d} + seconds(32);
+      auto lt = local_days{2000_y/January/1_d} + seconds(32);
       auto tt = clock_cast<tai_clock>(lt);
       assert(clock_cast<local_t>(tt) == lt);
 
-      auto lu = local_days{2000_y/01/01_d};
+      auto lu = local_days{2000_y/January/1_d};
       auto ut = clock_cast<utc_clock>(lu);
       assert(clock_cast<tai_clock>(ut) == tt);
    }
 
    /// gps epoch
    {
-     auto lg = local_days{1980_y/01/Sunday[1]};
+     auto lg = local_days{1980_y/January/Sunday[1]};
      auto gt = clock_cast<gps_clock>(lg);
      assert(clock_cast<local_t>(gt) == lg);
      assert(gt.time_since_epoch() == seconds(0));
 
-     auto lu = local_days{1980_y/01/Sunday[1]};
+     auto lu = local_days{1980_y/January/Sunday[1]};
      auto ut = clock_cast<utc_clock>(lu);
      assert(clock_cast<gps_clock>(ut) == gt);
 
-     auto lt = local_days{1980_y/01/Sunday[1]} + seconds(19);
+     auto lt = local_days{1980_y/January/Sunday[1]} + seconds(19);
      auto tt = clock_cast<tai_clock>(lt);
      assert(clock_cast<gps_clock>(tt) == gt);
    }
 
    // gps 2000 example
    {
-     auto lg = local_days{2000_y/01/01_d};
+     auto lg = local_days{2000_y/January/1_d};
      auto gt = clock_cast<gps_clock>(lg);
      assert(clock_cast<local_t>(gt) == lg);
 
-     auto lu = local_days{2000_y/01/01_d} - seconds(13);
+     auto lu = local_days{2000_y/January/1_d} - seconds(13);
      auto ut = clock_cast<utc_clock>(lu);
      assert(clock_cast<gps_clock>(ut) == gt);
 
-     auto lt = local_days{2000_y/01/01_d} + seconds(19);
+     auto lt = local_days{2000_y/January/1_d} + seconds(19);
      auto tt = clock_cast<tai_clock>(lt);
      assert(clock_cast<gps_clock>(tt) == gt);
    }


### PR DESCRIPTION
It was pointed out by my work colleague that use of numbers padded with zeros is a bad style - they are interpreted as octal literals, and works correctly (gives correct value), unless someone will want to configure September or 9th. 

This only affect local_t test, that I have recently added.