### PR TITLE
Suffix d for days duration

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -8225,7 +8225,6 @@ get_units(std::ratio<3600>)
     return string_literal<CharT, 2>{'h'};
 }
 
-
 template <class CharT>
 CONSTCD11
 inline
@@ -8233,6 +8232,15 @@ string_literal<CharT, 4>
 get_units(std::ratio<60>)
 {
     return string_literal<CharT, 4>{'m', 'i', 'n'};
+}
+
+template <class CharT>
+CONSTCD11
+inline
+string_literal<CharT, 2>
+get_units(std::ratio<86400>)
+{
+    return string_literal<CharT, 2>{'d'};
 }
 
 template <class CharT, class Traits = std::char_traits<CharT>>

--- a/test/date_test/durations_output.pass.cpp
+++ b/test/date_test/durations_output.pass.cpp
@@ -192,6 +192,14 @@ void test_calendar()
       assert(os.str() == "13h");
       os.str("");
    }
+
+   // days
+   {
+      days d(13);
+      os << d;
+      assert(os.str() == "13d");
+      os.str("");
+   }
 }
 
 void test_integral_scale()
@@ -214,14 +222,6 @@ void test_integral_scale()
       duration<int, std::ratio<25, 1>> d(13);
       os << d;
       assert(os.str() == "13[25]s");
-      os.str("");
-   }
-
-   // days = ratio 24 * 60 * 60 / 1 = ratio 86400 / 1
-   {
-      days d(13);
-      os << d;
-      assert(os.str() == "13[86400]s");
       os.str("");
    }
 
@@ -310,7 +310,8 @@ void test_constexpr()
 
   CONSTCD11 auto min = get_units<char>(std::ratio<60>{});
   CONSTCD11 auto h = get_units<char>(std::ratio<3600>{});
-  (void)min, (void)h;
+  CONSTCD11 auto d = get_units<char>(std::ratio<86400>{});
+  (void)min, (void)h, (void)d;
 
   CONSTCD14 auto integer = get_units<char>(std::ratio<123>{});
   CONSTCD14 auto ratio = get_units<char>(std::ratio<123, 3>{});


### PR DESCRIPTION
Changes the suffix used to days duration to single "d" instead of "[86400]s".
Updated test cases.