### PR TITLE
Workaround MSVC 19.14.26431 parsing bug

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -7811,7 +7811,7 @@ public:
     }
 
     template <class U = CharT,
-              class = typename std::enable_if<1 < sizeof(U)>::type>
+              class = typename std::enable_if<(1 < sizeof(U))>::type>
     CONSTCD14 string_literal(const char(&a)[N]) NOEXCEPT
         : p_{}
     {


### PR DESCRIPTION
Latest and greatest MSVC (15.7.4, cl.exe version 19.14.26431) is not able to parse date.h with pretty unhelpful error:
```
include\date\date.h(7856): error C2059: syntax error: '}'
include\date\date.h(7856): note: see reference to class template instantiation 'date::detail::string_literal<CharT,N>' being compiled
include\date\date.h(151): note: see reference to class template instantiation 'std::chrono::duration<int,std::ratio<86400,1>>' being compiled
include\date\date.h(7758): fatal error C1075: '{': no matching token found
```

The problem is actually this line:
```
   template <class U = CharT,
              class = typename std::enable_if<1 < sizeof(U)>::type>
```
I am not an C++ standard expert but, MSVC (at lease in my opinion) incorrectly interprets <
Workaround is to parenthesize the operator (at the cost of little additional ugliness)