### PR TITLE
Clean up zoned_traits along the lines described in my blog post.

### DIFF
--- a/include/date/ptz.h
+++ b/include/date/ptz.h
@@ -175,6 +175,33 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const time_zone& z);
 
     const time_zone* operator->() const {return this;}
+
+#if HAS_STRING_VIEW
+
+    static
+    time_zone
+    locate_zone(std::string_view name)
+    {
+        return time_zone{name};
+    }
+
+#else  // !HAS_STRING_VIEW
+
+    static
+    time_zone
+    locate_zone(const std::string& name)
+    {
+        return time_zone{name};
+    }
+
+    static
+    time_zone
+    locate_zone(const char* name)
+    {
+        return time_zone{name};
+    }
+
+#endif  // !HAS_STRING_VIEW
 };
 
 inline
@@ -550,43 +577,5 @@ read_unsigned(const string_t& s, unsigned i, unsigned limit, unsigned& u)
 }  // namespace detail
 
 }  // namespace Posix
-
-namespace date
-{
-
-template <>
-struct zoned_traits<Posix::time_zone>
-{
-
-#if HAS_STRING_VIEW
-
-    static
-    Posix::time_zone
-    locate_zone(std::string_view name)
-    {
-        return Posix::time_zone{name};
-    }
-
-#else  // !HAS_STRING_VIEW
-
-    static
-    Posix::time_zone
-    locate_zone(const std::string& name)
-    {
-        return Posix::time_zone{name};
-    }
-
-    static
-    Posix::time_zone
-    locate_zone(const char* name)
-    {
-        return Posix::time_zone{name};
-    }
-
-#endif  // !HAS_STRING_VIEW
-
-};
-
-}  // namespace date
 
 #endif  // PTZ_H

--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -284,6 +284,39 @@ DATE_API const time_zone* current_zone();
 template <class T>
 struct zoned_traits
 {
+    template<class T_ = T>
+    static auto
+    default_zone() -> decltype(T_::default_zone())
+    {
+        return T::default_zone();
+    }
+
+#if HAS_STRING_VIEW
+
+    template<class T_ = T>
+    static auto
+    locate_zone(std::string_view name) -> decltype(T_::locate_zone(name))
+    {
+        return T::locate_zone(name);
+    }
+
+#else  // !HAS_STRING_VIEW
+
+    template<class T_ = T>
+    static auto
+    locate_zone(const std::string& name) -> decltype(T_::locate_zone(name))
+    {
+        return T::locate_zone(name);
+    }
+
+    template<class T_ = T>
+    static auto
+    locate_zone(const char* name) -> decltype(T_::locate_zone(name))
+    {
+        return T::locate_zone(name);
+    }
+
+#endif  // !HAS_STRING_VIEW
 };
 
 template <>


### PR DESCRIPTION
https://quuxplusone.github.io/blog/2018/07/14/traits-classes/#finally-already-in-the-c-2a-work

This new design mimics pointer_traits, iterator_traits, allocator_traits
by forwarding along behavior defined in the user-provided class
(or, optionally, a sensible default behavior, if the user-provided
class didn't define any behavior; but in the case of zoned_traits
all the desired defaults thus far are just "SFINAE away", so we do that).

This means that `Posix::time_zone` no longer has to reopen `namespace date`
to get the behavior it wants. It also means that non-Howard users
(say, `Foo::time_zone`) don't ever have to open `namespace date` at all;
and that the `date` library itself remains free to add new customization
points into `zoned_traits` without breaking any existing code.

(If existing code specialized `zoned_traits`, then that code would break
when `date` added new members to `zoned_traits`.)

This is a proof-of-concept. I'd be thrilled if it got in, but I'm not
going to expend more effort pushing for it this week.