### PR TITLE
Make HAS_STRING_VIEW compiler definition part of the public interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if( USE_TZ_DB_IN_DOT )
 endif( )
 
 if( DISABLE_STRING_VIEW )
-    target_compile_definitions( tz PRIVATE -DHAS_STRING_VIEW=0 )
+    target_compile_definitions( tz PUBLIC -DHAS_STRING_VIEW=0 )
 endif( )
 
 if( BUILD_SHARED_LIBS )


### PR DESCRIPTION
Consumers of the library has to be informed about the state of HAS_STRING_VIEW as it changes functions in the public interface.