### PR TITLE
Export all cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ add_library( date::date ALIAS date )
 
 # add include folders to the INTERFACE and targets that consume it
 target_include_directories( date INTERFACE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>"
+	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+	"$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>"
 )
 
 add_library( tz ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
@@ -80,91 +80,78 @@ if( USE_TZ_DB_IN_DOT )
 endif( )
 
 if( DISABLE_STRING_VIEW )
-    target_compile_definitions( tz PRIVATE -DHAS_STRING_VIEW=0 )
+	target_compile_definitions( tz PRIVATE -DHAS_STRING_VIEW=0 )
 endif( )
 
 if( BUILD_SHARED_LIBS )
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC")
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC")
 endif( )
 
 target_link_libraries( tz
-  date::date
-  ${CMAKE_THREAD_LIBS_INIT}
+	date::date
+	Threads::Threads
 )
 
 install( TARGETS date EXPORT date-targets )
 install( TARGETS tz EXPORT date-targets
 	ARCHIVE
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT lib
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    		COMPONENT lib
 	LIBRARY
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT lib
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		COMPONENT lib
 	RUNTIME # This is for DLLs on Windows
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT lib
+		DESTINATION ${CMAKE_INSTALL_BINDIR}
+		COMPONENT lib
 )
 install( DIRECTORY ${HEADER_FOLDER}/
-  DESTINATION
-    include/
-  COMPONENT
-    dev
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  	COMPONENT dev
 )
 
 # Create package build configuration in build directory
 
 export( EXPORT date-targets
-  FILE
-    "${CMAKE_CURRENT_BINARY_DIR}/date-targets.cmake"
-  NAMESPACE
-    date::
+	FILE "${CMAKE_CURRENT_BINARY_DIR}/date-targets.cmake"
+	NAMESPACE date::
 )
 
 write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/date-config-version.cmake"
-  VERSION
-    ${${PROJECT_NAME}_VERSION}
-  COMPATIBILITY
-    AnyNewerVersion
+  	"${CMAKE_CURRENT_BINARY_DIR}/date-config-version.cmake"
+  	VERSION ${${PROJECT_NAME}_VERSION}
+  	COMPATIBILITY AnyNewerVersion
 )
 
 configure_package_config_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/date-config.cmake.in"
-  "date-config.cmake"
-  INSTALL_DESTINATION
-    "${CMAKE_CURRENT_BINARY_DIR}"
+  	"${CMAKE_CURRENT_SOURCE_DIR}/date-config.cmake.in"
+  	"date-config.cmake"
+  	INSTALL_DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
-# Export build configuration into local cmake repository
+# Export build configuration into cmake user repository
 
 export( PACKAGE date )
 
 # Install package configuration for installed targets
 
 if(WIN32 AND NOT CYGWIN)
-  set(DEF_INSTALL_CMAKE_DIR CMake)
+  	set(DEF_INSTALL_CMAKE_DIR CMake)
 else()
-  set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/date)
+  	set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/date)
 endif()
 
 install( EXPORT date-targets
-  DESTINATION
-    ${DEF_INSTALL_CMAKE_DIR}
-  NAMESPACE
-    date::
-  COMPONENT
-    dev
+  	DESTINATION ${DEF_INSTALL_CMAKE_DIR}
+  	NAMESPACE   date::
+  	COMPONENT   dev
 )
 
 install(
-  FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/date-config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/date-config-version.cmake"
-  DESTINATION
-    ${DEF_INSTALL_CMAKE_DIR}
-  COMPONENT
-    dev
+	FILES	"${CMAKE_CURRENT_BINARY_DIR}/date-config.cmake"
+    		"${CMAKE_CURRENT_BINARY_DIR}/date-config-version.cmake"
+	DESTINATION ${DEF_INSTALL_CMAKE_DIR}
+	COMPONENT dev
 )
 
 # Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ else( )
 	target_compile_definitions( tz PUBLIC -DUSE_OS_TZDB=0 )
 	find_package( CURL REQUIRED )
 	target_include_directories( tz PRIVATE ${CURL_INCLUDE_DIRS} )
-	target_link_libraries( tz ${CURL_LIBRARIES} )
+	target_link_libraries( tz PRIVATE ${CURL_LIBRARIES} )
 endif( )
 
 if( USE_TZ_DB_IN_DOT )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ set( HEADER_FILES
 add_library( date INTERFACE)
 add_library( date::date ALIAS date )
 
+set_target_properties( date PROPERTIES VERSION ${PROJECT_VERSION} )
+
 # add include folders to the INTERFACE and targets that consume it
 target_include_directories( date INTERFACE
 	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -58,6 +60,8 @@ target_include_directories( date INTERFACE
 
 add_library( tz ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
 add_library( date::tz ALIAS tz )
+
+set_target_properties( tz PROPERTIES VERSION ${PROJECT_VERSION} )
 
 if( USE_SYSTEM_TZ_DB )
 	target_compile_definitions( tz PRIVATE -DUSE_AUTOLOAD=0 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,6 @@ set( HEADER_FILES
 add_library( date INTERFACE)
 add_library( date::date ALIAS date )
 
-set_target_properties( date PROPERTIES VERSION ${PROJECT_VERSION} )
-
 # add include folders to the INTERFACE and targets that consume it
 target_include_directories( date INTERFACE
 	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,10 @@ if( BUILD_SHARED_LIBS )
 endif( )
 
 target_link_libraries( tz
-	date::date
-	Threads::Threads
+	PUBLIC
+		date::date
+	PRIVATE
+		Threads::Threads
 )
 
 install( TARGETS date EXPORT date-targets )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required( VERSION 3.1.0 )
 
-project( date_prj )
+project( date_prj VERSION 2.4.1 )
 
 include( GNUInstallDirs )
+
+include( CMakePackageConfigHelpers )
 
 find_package( Threads REQUIRED )
 
@@ -45,7 +47,17 @@ set( HEADER_FILES
 	${HEADER_FOLDER}/date/tz_private.h
 )
 
+add_library( date INTERFACE)
+add_library( date::date ALIAS date )
+
+# add include folders to the INTERFACE and targets that consume it
+target_include_directories( date INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>"
+)
+
 add_library( tz ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
+add_library( date::tz ALIAS tz )
 
 if( USE_SYSTEM_TZ_DB )
 	target_compile_definitions( tz PRIVATE -DUSE_AUTOLOAD=0 )
@@ -59,8 +71,8 @@ else( )
 	target_compile_definitions( tz PRIVATE -DHAS_REMOTE_API=1 )
 	target_compile_definitions( tz PUBLIC -DUSE_OS_TZDB=0 )
 	find_package( CURL REQUIRED )
-	include_directories( SYSTEM ${CURL_INCLUDE_DIRS} )
-	set( OPTIONAL_LIBRARIES ${CURL_LIBRARIES} )
+	target_include_directories( tz PRIVATE ${CURL_INCLUDE_DIRS} )
+	target_link_libraries( tz ${CURL_LIBRARIES} )
 endif( )
 
 if( USE_TZ_DB_IN_DOT )
@@ -76,39 +88,86 @@ if( BUILD_SHARED_LIBS )
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC")
 endif( )
 
-target_link_libraries( tz ${CMAKE_THREAD_LIBS_INIT} ${OPTIONAL_LIBRARIES} )
-
-# add include folders to the library and targets that consume it
-target_include_directories(tz PUBLIC
-    $<BUILD_INTERFACE:
-        ${CMAKE_CURRENT_SOURCE_DIR}/${HEADER_FOLDER}
-    >
-    $<INSTALL_INTERFACE:
-        include
-    >
+target_link_libraries( tz
+  date::date
+  ${CMAKE_THREAD_LIBS_INIT}
 )
 
-add_library(date_interface INTERFACE) # an interface (not a library), to enable automatic include_directory (for when just date.h, but not "tz.h and its lib" are needed)
-
-# add include folders to the INTERFACE and targets that consume it
-target_include_directories(date_interface INTERFACE
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    $<INSTALL_INTERFACE:include>
+install( TARGETS date EXPORT date-targets )
+install( TARGETS tz EXPORT date-targets
+	ARCHIVE
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT lib
+	LIBRARY
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT lib
+	RUNTIME # This is for DLLs on Windows
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT lib
 )
+install( DIRECTORY ${HEADER_FOLDER}/
+  DESTINATION
+    include/
+  COMPONENT
+    dev
+)
+
+# Create package build configuration in build directory
+
+export( EXPORT date-targets
+  FILE
+    "${CMAKE_CURRENT_BINARY_DIR}/date-targets.cmake"
+  NAMESPACE
+    date::
+)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/date-config-version.cmake"
+  VERSION
+    ${${PROJECT_NAME}_VERSION}
+  COMPATIBILITY
+    AnyNewerVersion
+)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/date-config.cmake.in"
+  "date-config.cmake"
+  INSTALL_DESTINATION
+    "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+# Export build configuration into local cmake repository
+
+export( PACKAGE date )
+
+# Install package configuration for installed targets
 
 if(WIN32 AND NOT CYGWIN)
-    set(DEF_INSTALL_CMAKE_DIR CMake)
+  set(DEF_INSTALL_CMAKE_DIR CMake)
 else()
-    set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/date)
+  set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/date)
 endif()
 
-install( TARGETS date_interface EXPORT dateConfig )
-install( EXPORT dateConfig DESTINATION ${DEF_INSTALL_CMAKE_DIR} )
-install( TARGETS tz
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})  # This is for Windows
-install( DIRECTORY ${HEADER_FOLDER}/ DESTINATION include/ )
+install( EXPORT date-targets
+  DESTINATION
+    ${DEF_INSTALL_CMAKE_DIR}
+  NAMESPACE
+    date::
+  COMPONENT
+    dev
+)
+
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/date-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/date-config-version.cmake"
+  DESTINATION
+    ${DEF_INSTALL_CMAKE_DIR}
+  COMPONENT
+    dev
+)
+
+# Tests
 
 if ( ENABLE_DATE_TESTING )
 

--- a/date-config.cmake.in
+++ b/date-config.cmake.in
@@ -4,6 +4,7 @@ include( CMakeFindDependencyMacro )
 
 find_dependency( Threads )
 
+# CURL is required if ${USE_SYSTEM_TZ_DB} is OFF
 if( NOT @USE_SYSTEM_TZ_DB@ )
 	find_dependency( CURL )
 endif()
@@ -11,3 +12,7 @@ endif()
 include( "${CMAKE_CURRENT_LIST_DIR}/date-targets.cmake" )
 
 # include( "${CMAKE_CURRENT_LIST_DIR}/date-macros.cmake" )
+
+set( date_FOUND TRUE )
+
+check_required_components( date )

--- a/date-config.cmake.in
+++ b/date-config.cmake.in
@@ -4,11 +4,6 @@ include( CMakeFindDependencyMacro )
 
 find_dependency( Threads )
 
-# CURL is required if ${USE_SYSTEM_TZ_DB} is OFF
-if( NOT @USE_SYSTEM_TZ_DB@ )
-	find_dependency( CURL )
-endif()
-
 include( "${CMAKE_CURRENT_LIST_DIR}/date-targets.cmake" )
 
 check_required_components( date )

--- a/date-config.cmake.in
+++ b/date-config.cmake.in
@@ -1,0 +1,13 @@
+@PACKAGE_INIT@
+
+include( CMakeFindDependencyMacro )
+
+find_dependency( Threads )
+
+if( NOT @USE_SYSTEM_TZ_DB@ )
+	find_dependency( CURL )
+endif()
+
+include( "${CMAKE_CURRENT_LIST_DIR}/date-targets.cmake" )
+
+# include( "${CMAKE_CURRENT_LIST_DIR}/date-macros.cmake" )

--- a/date-config.cmake.in
+++ b/date-config.cmake.in
@@ -11,8 +11,4 @@ endif()
 
 include( "${CMAKE_CURRENT_LIST_DIR}/date-targets.cmake" )
 
-# include( "${CMAKE_CURRENT_LIST_DIR}/date-macros.cmake" )
-
-set( date_FOUND TRUE )
-
 check_required_components( date )


### PR DESCRIPTION
Hi,
this fixes  #367 by providing a complete package configuration and also modernizes the `CMakeLists.txt` file:
* Remove target `date_interface`
* Introduce alias and export targets `date::date` and `date::tz`
  * Export a build package configuration into the [cmake registry](https://cmake.org/cmake/help/v3.0/manual/cmake-packages.7.html#package-registry)
  * Export an install package configuration
* Add version information to the project and the exported package configurations
* Minimize use of cmake variables
* Replace old-fashioned directory-level commands (`include_directories`,...) with target-level counterparts (`target_include_directories`,...) 

Note: 
* using targets in namespaces (containing `::`) allows cmake to detect missing dependencies during configuration (instead of linking)
* see this great [talk](https://www.youtube.com/watch?v=bsXLMQ6WgIk) for details on package configurations and modern cmake usage