### PR TITLE
Improved C++17 support

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -69,7 +69,7 @@
 #    elif __has_include(<experimental/string_view>)
 #      include <experimental/string_view>
        namespace std {
-           typedef experimental::string_view string_view;
+           using string_view = experimental::string_view;
        }
 #    endif
 #  endif

--- a/include/date/date.h
+++ b/include/date/date.h
@@ -63,7 +63,16 @@
 #include <stdexcept>
 #include <string>
 #if HAS_STRING_VIEW
-# include <string_view>
+#  if defined(__has_include)
+#    if __has_include(<string_view>)
+#      include <string_view>
+#    elif __has_include(<experimental/string_view>)
+#      include <experimental/string_view>
+       namespace std {
+           typedef experimental::string_view string_view;
+       }
+#    endif
+#  endif
 #endif
 #include <utility>
 #include <type_traits>
@@ -128,7 +137,16 @@ namespace date
 
 #ifndef HAS_VOID_T
 #  if __cplusplus >= 201703
-#    define HAS_VOID_T 1
+#    if defined(__has_include)
+#      define HAS_VOID_T 1
+#      if __has_include(<experimental/type_traits>)
+#        include <experimental/type_traits>
+         namespace std {
+             typedef experimental::void_t void_t;
+		 }
+#    endif
+#  endif
+#endif
 #  else
 #    define HAS_VOID_T 0
 #  endif


### PR DESCRIPTION
Some C++ compiler (such as clang 5.0) have std::void_t and std::string_view in std::experimental namespace.
This workaround checks if the compiler has the experimental namespace and includes the correct files (remapping them to std namespace)