### PR TITLE
Detect std::string_view using __cpp_lib_string_view.

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -31,14 +31,6 @@
 // been invented (that would involve another several millennia of evolution).
 // We did not mean to shout.
 
-#ifndef HAS_STRING_VIEW
-#  if __cplusplus >= 201703
-#    define HAS_STRING_VIEW 1
-#  else
-#    define HAS_STRING_VIEW 0
-#  endif
-#endif  // HAS_STRING_VIEW
-
 #include <cassert>
 #include <algorithm>
 #include <cctype>
@@ -62,6 +54,13 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#ifndef HAS_STRING_VIEW
+#  if __cpp_lib_string_view >= 201606
+#    define HAS_STRING_VIEW 1
+#  else
+#    define HAS_STRING_VIEW 0
+#  endif
+#endif  // HAS_STRING_VIEW
 #if HAS_STRING_VIEW
 # include <string_view>
 #endif


### PR DESCRIPTION
This allows us to cope with situations where the compiler may support
C++17, but the standard library implementation may not be complete.

I ran into this situation when attempting to build with clang and libc++ on Ubuntu 17.10, which has clang 5.0 but ships with libc++ 3.9.1. The compiler sets __cplusplus to a value which indicates C++17 support, but the library does not have std::string_view.