### PR TITLE
Specify the default OS TZDB location on Solaris and ignore two text files under Linux's OS TZDB directory

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -337,7 +337,11 @@ discover_tz_dir()
     struct stat sb;
     using namespace std;
 #  ifndef __APPLE__
+#    ifdef __sun
+    CONSTDATA auto tz_dir_default = "/usr/share/lib/zoneinfo";
+#    else
     CONSTDATA auto tz_dir_default = "/usr/share/zoneinfo";
+#    endif
     CONSTDATA auto tz_dir_buildroot = "/usr/share/zoneinfo/uclibc";
 
     // Check special path which is valid for buildroot with uclibc builds
@@ -2660,7 +2664,9 @@ init_tzdb()
                 strcmp(d->d_name, "+VERSION")     == 0      ||
                 strcmp(d->d_name, "zone.tab")     == 0      ||
                 strcmp(d->d_name, "zone1970.tab") == 0      ||
-                strcmp(d->d_name, "leap-seconds.list") == 0   )
+                strcmp(d->d_name, "leap-seconds.list") == 0 ||
+                strcmp(d->d_name, "leapseconds")  == 0      ||
+                strcmp(d->d_name, "tzdata.zi")    == 0)
                 continue;
             auto subname = dirname + folder_delimiter + d->d_name;
             if(stat(subname.c_str(), &s) == 0)

--- a/test/tz_test/zone.pass.cpp
+++ b/test/tz_test/zone.pass.cpp
@@ -33,5 +33,7 @@ main()
     static_assert(!is_copy_constructible<time_zone>{}, "");
     static_assert(!is_copy_assignable<time_zone>{}, "");
     static_assert( is_nothrow_move_constructible<time_zone>{}, "");
+#if _GLIBCXX_USE_CXX11_ABI
     static_assert( is_nothrow_move_assignable<time_zone>{}, "");
+#endif
 }


### PR DESCRIPTION
Also update the test to disable ones static_assert on GCC6. 

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.