### PR TITLE
add c_encoding and iso_encoding weekday functions

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -429,6 +429,9 @@ public:
 
     CONSTCD11 bool ok() const NOEXCEPT;
 
+    CONSTCD11 unsigned c_encoding() const NOEXCEPT;
+    CONSTCD11 unsigned iso_encoding() const NOEXCEPT;
+
     CONSTCD11 weekday_indexed operator[](unsigned index) const NOEXCEPT;
     CONSTCD11 weekday_last    operator[](last_spec)      const NOEXCEPT;
 
@@ -1762,6 +1765,20 @@ weekday::operator-=(const days& d) NOEXCEPT
 }
 
 CONSTCD11 inline bool weekday::ok() const NOEXCEPT {return wd_ <= 6;}
+
+CONSTCD11
+inline
+unsigned weekday::c_encoding() const NOEXCEPT
+{
+    return unsigned{wd_};
+}
+
+CONSTCD11
+inline
+unsigned weekday::iso_encoding() const NOEXCEPT
+{
+    return unsigned{((wd_ == 0u) ? 7u : wd_)};
+}
 
 CONSTCD11
 inline


### PR DESCRIPTION
- c_encoding satisfies ctime wday encoding: days since Sunday, range
  [0,6]
- iso_encoding satisfies ISO 8601 weekday:
  a digit d from 1 through 7, beginning with Monday and ending with Sunday

in reference to: https://github.com/HowardHinnant/date/issues/378