### PR TITLE
add basic CI using travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,112 @@
+sudo: required
+language: cpp
+services:
+  - docker
+
+# define the build matrix
+env:
+  global:
+    - PROJECT_DIR: .
+    - TOOLCHAIN: default
+    - BUILD_PACKAGES: ""
+    - DISABLE_STRING_VIEW: NO
+    - TZ: America/Los_Angeles
+matrix:
+  include:
+    # Linux {
+
+    # Ubuntu 16.04
+    - os: linux
+      # disable string_view, no C++17 compiler available
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=xenial
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx11
+        DISABLE_STRING_VIEW=YES
+    # Ubuntu 18.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx11
+        DISABLE_STRING_VIEW=YES
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx14
+        DISABLE_STRING_VIEW=YES
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx17
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=clang-cxx11
+        DISABLE_STRING_VIEW=YES
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=clang-cxx14
+        DISABLE_STRING_VIEW=YES
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=clang-cxx17
+
+    # Debian 8
+    - os: linux
+      # disable string_view, no C++17 compiler available
+      env: >
+        BUILD_FLAVOR=debian
+        BUILD_RELEASE=stretch
+        BUILD_ARCH=amd64
+        DISABLE_STRING_VIEW=YES
+    # Debian 9
+    - os: linux
+      env: >
+        BUILD_FLAVOR=debian
+        BUILD_RELEASE=buster
+        BUILD_ARCH=amd64
+    # } // end Linux
+
+before_install:
+  # use the Dockerfile.<distro>.template file for building the image with sed magic
+  - |
+    sed \
+    -e "s/@BUILD_FLAVOR@/${BUILD_FLAVOR}/g" \
+    -e "s/@BUILD_RELEASE@/${BUILD_RELEASE}/g" \
+    -e "s/@BUILD_ARCH@/${BUILD_ARCH}/g" \
+    -e "s/@BUILD_PACKAGES@/${BUILD_PACKAGES}/g" \
+    -e "s#@TZ@#${TZ}#g" \
+    ci/Dockerfile.template | tee ci/Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH
+  - docker build -f ci/Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH -t date-devel .
+
+script: |
+  # run the respective .travis.<distro>.sh script
+  docker run \
+  -e BUILD_FLAVOR="$BUILD_FLAVOR" \
+  -e BUILD_RELEASE="$BUILD_RELEASE" \
+  -e BUILD_ARCH="$BUILD_ARCH" \
+  -e PROJECT_DIR="$PROJECT_DIR" \
+  -e TOOLCHAIN="$TOOLCHAIN" \
+  -e DISABLE_STRING_VIEW="$DISABLE_STRING_VIEW" \
+  -it date-devel ./ci/travis.sh
+

--- a/ci/Dockerfile.template
+++ b/ci/Dockerfile.template
@@ -1,0 +1,22 @@
+# Build Debian/Ubuntu image
+FROM @BUILD_ARCH@/@BUILD_FLAVOR@:@BUILD_RELEASE@
+
+# set timezone such that tzdata install successfully
+# https://serverfault.com/questions/683605/docker-container-time-timezone-will-not-reflect-changes
+ENV TZ=@TZ@
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  @BUILD_PACKAGES@ \
+  tzdata \
+  build-essential \
+  cmake \
+  g++ \
+  clang
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app

--- a/ci/toolchains/.gitignore
+++ b/ci/toolchains/.gitignore
@@ -1,0 +1,2 @@
+# allow toolchain files to be tracked by git
+!*.cmake

--- a/ci/toolchains/clang-cxx11.cmake
+++ b/ci/toolchains/clang-cxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/clang-cxx14.cmake
+++ b/ci/toolchains/clang-cxx14.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/clang-cxx17.cmake
+++ b/ci/toolchains/clang-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/default.cmake
+++ b/ci/toolchains/default.cmake
@@ -1,0 +1,1 @@
+# dummy toolchain

--- a/ci/toolchains/gcc-cxx11.cmake
+++ b/ci/toolchains/gcc-cxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx14.cmake
+++ b/ci/toolchains/gcc-cxx14.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx17.cmake
+++ b/ci/toolchains/gcc-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx98.cmake
+++ b/ci/toolchains/gcc-cxx98.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-gnuxx11.cmake
+++ b/ci/toolchains/gcc-gnuxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+set -x
+
+uname -a
+
+cmake -H. -B_build_${TOOLCHAIN} -DCMAKE_TOOLCHAIN_FILE="${PWD}/ci/toolchains/${TOOLCHAIN}.cmake" \
+	-DUSE_SYSTEM_TZ_DB=ON \
+	-DENABLE_DATE_TESTING=ON \
+	-DDISABLE_STRING_VIEW=${DISABLE_STRING_VIEW}
+cmake --build _build_${TOOLCHAIN} --target testit -- -j4
+


### PR DESCRIPTION
- docker images
  - Ubuntu 16.04 (xenial)
  - Ubuntu 18.04 (bionic)
  - Debian 8 (stretch)
  - Debian 9 (buster)
- compile targets (gcc and clang)
  - C++11
  - C++14
  - C++17

Tests on Ubuntu 16.04 and Debian 8 fail because C++17 seems to be always set, even when preset by the CMake-Toolchain file. This would be fixed by https://github.com/HowardHinnant/date/pull/379

Builds can be seen here: https://travis-ci.org/NeroBurner/date/builds/424082905

For C++17 capable compilers the test 38 `date_test_pass_parse_test` fails (both gcc and clang). Ref: https://github.com/HowardHinnant/date/issues/334