### PR TITLE
Standalone version allowing to provide the database as std::istream

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -2757,6 +2757,18 @@ to_gps_time(const tai_time<Duration>& t)
 
 #endif  // !MISSING_LEAP_SECONDS
 
+using database_stream_getter = std::unique_ptr<std::istream> (*)(void);
+
+// set IANA database source as intput stream
+DATE_API void
+set_iana_db_source_stream(database_stream_getter);
+
+#ifdef _WIN32
+// set Windows time zone database source as input stream
+DATE_API void
+set_windows_xml_source_stream(database_stream_getter);
+#endif
+
 }  // namespace date
 
 #endif  // TZ_H


### PR DESCRIPTION
This makes it possible to embed the database in a string in the source
code so that the library is completely standalone. No need to download
the database, no need to read it from disk files.

Notice that this not a new format. The embedded file should just be a concatenation of the IANA database files.

With this commit, you can compile with -DHAS_REMOTE_API=0
-DAUTO_DOWNLOAD=0 and still have access to the database like this:

date::set_iana_db_source_stream(&iana_getter);
date::set_windows_xml_source_stream(&win_xml_getter);

where iana_getter() and win_xml_getter() both return a
std::unique_ptr<std::istream>.

The stream returned by iana_getter() is the concatenation of files:
version africa antarctica asia australasia backward etcetera europe
pacificnew northamerica southamerica systemv leapseconds from
https://data.iana.org/time-zones/releases/tzdata${version}.tar.gz.

The stream returned by win_xml_getter is the content of the file
http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml.

Fixes issue #368.

Example of how it can be used in the attached file.
[standalone-db.cpp.gz](https://github.com/HowardHinnant/date/files/2382396/standalone-db.cpp.gz)
