### PR TITLE
Prefer using std::string that using namespace std and unqualified string

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -4493,8 +4493,7 @@ inline
 std::pair<const std::string*, const std::string*>
 weekday_names()
 {
-    using namespace std;
-    static const string nm[] =
+    static const std::string nm[] =
     {
         "Sunday",
         "Monday",
@@ -4511,15 +4510,14 @@ weekday_names()
         "Fri",
         "Sat"
     };
-    return make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
+    return std::make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
 }
 
 inline
 std::pair<const std::string*, const std::string*>
 month_names()
 {
-    using namespace std;
-    static const string nm[] =
+    static const std::string nm[] =
     {
         "January",
         "February",
@@ -4546,20 +4544,19 @@ month_names()
         "Nov",
         "Dec"
     };
-    return make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
+    return std::make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
 }
 
 inline
 std::pair<const std::string*, const std::string*>
 ampm_names()
 {
-    using namespace std;
-    static const string nm[] =
+    static const std::string nm[] =
     {
         "AM",
         "PM"
     };
-    return make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
+    return std::make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
 }
 
 template <class CharT, class Traits, class FwdIter>

--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -1963,10 +1963,9 @@ std::basic_ostream<CharT, Traits>&
 to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
           const utc_time<Duration>& t)
 {
-    using namespace std;
     using namespace std::chrono;
-    using CT = typename common_type<Duration, seconds>::type;
-    const string abbrev("UTC");
+    using CT = typename std::common_type<Duration, seconds>::type;
+    const std::string abbrev("UTC");
     CONSTDATA seconds offset{0};
     auto ls = is_leap_second(t);
     auto tp = sys_time<CT>{t.time_since_epoch() - ls.second};
@@ -1992,16 +1991,15 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
             utc_time<Duration>& tp, std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
             std::chrono::minutes* offset = nullptr)
 {
-    using namespace std;
     using namespace std::chrono;
-    using CT = typename common_type<Duration, seconds>::type;
+    using CT = typename std::common_type<Duration, seconds>::type;
     minutes offset_local{};
     auto offptr = offset ? offset : &offset_local;
     fields<CT> fds{};
     fds.has_tod = true;
     from_stream(is, fmt, fds, abbrev, offptr);
     if (!fds.ymd.ok())
-        is.setstate(ios::failbit);
+        is.setstate(std::ios::failbit);
     if (!is.fail())
     {
         bool is_60_sec = fds.tod.seconds() == seconds{60};
@@ -2012,7 +2010,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
             tmp += seconds{1};
         if (is_60_sec != is_leap_second(tmp).first || !fds.tod.in_conventional_range())
         {
-            is.setstate(ios::failbit);
+            is.setstate(std::ios::failbit);
             return is;
         }
         tp = time_point_cast<Duration>(tmp);


### PR DESCRIPTION
'using namespace std;' in header files can conflict with custom
namespace names. For example 'string' is used without 'std::'
qualification in tz.h. If tz.h is included in a file where string is a
namespace, it cannot be compiled anymore.

This is the case in my program where I put anything related to strings inside namespace string.

This fixes only the issue with string but I think other using namespace should be removed from all .h to avoid any bad surprises.