### PR TITLE
Define for std::uncaught_exceptions(). 

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -132,7 +132,7 @@ namespace date
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0
 #  endif
-#endif  // HAS_VOID_T   
+#endif  // HAS_UNCAUGHT_EXCEPTIONS   
 
 #ifndef HAS_VOID_T
 #  if __cplusplus >= 201703

--- a/include/date/date.h
+++ b/include/date/date.h
@@ -126,14 +126,6 @@ namespace date
 #  define NOEXCEPT noexcept
 #endif
 
-#ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cpp_lib_uncaught_exceptions
-#    define HAS_UNCAUGHT_EXCEPTIONS 1
-#  else
-#    define HAS_UNCAUGHT_EXCEPTIONS 0
-#  endif
-#endif  // HAS_UNCAUGHT_EXCEPTIONS   
-
 #ifndef HAS_VOID_T
 #  if __cplusplus >= 201703
 #    define HAS_VOID_T 1
@@ -1035,7 +1027,7 @@ public:
     ~save_ostream()
     {
         if ((this->flags_ & std::ios::unitbuf) &&
-#if HAS_UNCAUGHT_EXCEPTIONS
+#if __cpp_lib_uncaught_exceptions
                 std::uncaught_exceptions() == 0 &&
 #else
                 !std::uncaught_exception() &&

--- a/include/date/date.h
+++ b/include/date/date.h
@@ -126,6 +126,14 @@ namespace date
 #  define NOEXCEPT noexcept
 #endif
 
+#ifndef HAS_UNCAUGHT_EXCEPTIONS
+#  if __cplusplus >= 201703
+#    define HAS_UNCAUGHT_EXCEPTIONS 1
+#  else
+#    define HAS_UNCAUGHT_EXCEPTIONS 0
+#  endif
+#endif  // HAS_VOID_T   
+
 #ifndef HAS_VOID_T
 #  if __cplusplus >= 201703
 #    define HAS_VOID_T 1
@@ -1027,7 +1035,7 @@ public:
     ~save_ostream()
     {
         if ((this->flags_ & std::ios::unitbuf) &&
-#if __cplusplus >= 201703
+#if HAS_UNCAUGHT_EXCEPTIONS
                 std::uncaught_exceptions() == 0 &&
 #else
                 !std::uncaught_exception() &&

--- a/include/date/date.h
+++ b/include/date/date.h
@@ -127,7 +127,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus >= 201703
+#  if __cpp_lib_uncaught_exceptions
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0


### PR DESCRIPTION
Xcode 10 uses clang and perfectly compiles C++17, but std::uncaught_exceptions() is available only on iOS 10+ devices. When application supports iOS 9 devices and uses C++17 there is no way to build it, except drop iOS 9 support or remove C++17 code. Using this define we could configure should date.h use std::uncaught_exceptions() or not.