### PR TITLE
Fix bug parsing locale date (%x)

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -6376,7 +6376,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     {
 #if !ONLY_C_LOCALE
                         ios_base::iostate err = ios_base::goodbit;
-                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+						f.get_date(is, nullptr, is, err, &tm);
                         if ((err & ios::failbit) == 0)
                         {
                             checked_set(Y, tm.tm_year + 1900, not_a_year, is);

--- a/test/date_test/parse/locale_date.pass.cpp
+++ b/test/date_test/parse/locale_date.pass.cpp
@@ -1,0 +1,53 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Howard Hinnant
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "date.h"
+
+#include <cassert>
+#include <iostream>
+#include <type_traits>
+#include <locale>
+
+int
+main()
+{
+  using namespace date;
+  using namespace std::chrono;
+
+  std::locale loc("en-US");
+
+	std::istringstream iss("3/10/18");
+	iss.imbue(loc);
+
+	date::local_seconds tLocal;
+	iss >> date::parse("%x", tLocal);
+
+  // Seconds since Epoch for the 10th of march
+	assert(tLocal.time_since_epoch().count() == 1520640000);
+
+  iss.imbue(std::locale("de-DE"));
+  iss >> date::parse("%x", tLocal);
+
+  // Seconds since Epoch for the 3rd of october
+  assert(tLocal.time_since_epoch().count() == 1538524800);
+
+}


### PR DESCRIPTION
Parsing istringstream formated as "%x" and "%x %X" was switching day and month.