### PR TITLE
Ignore tzdata.zi and leapseconds tzdb files on Linux when loading time zones

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2660,6 +2660,8 @@ init_tzdb()
                 strcmp(d->d_name, "+VERSION")     == 0      ||
                 strcmp(d->d_name, "zone.tab")     == 0      ||
                 strcmp(d->d_name, "zone1970.tab") == 0      ||
+                strcmp(d->d_name, "tzdata.zi")    == 0      ||
+                strcmp(d->d_name, "leapseconds")  == 0      ||
                 strcmp(d->d_name, "leap-seconds.list") == 0   )
                 continue;
             auto subname = dirname + folder_delimiter + d->d_name;


### PR DESCRIPTION
Hi Howard

Thanks for this great library!
When loading tzdb files on Linux 2 additional files are considered to be time zones.  And when enumerating time zones they are listed as valid time zones. This patch just skips them.

Kind regards,
Albert