### PR TITLE
Fix warnings from Clang

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -212,7 +212,7 @@ get_known_folder(const GUID& folderid)
         const wchar_t* fptr = folder_ptr.get();
         auto state = std::mbstate_t();
         const auto required = std::wcsrtombs(nullptr, &fptr, 0, &state);
-        if (required != 0 && required != -1)
+        if (required != 0 && required != std::size_t(-1))
         {
             folder.resize(required);
             std::wcsrtombs(&folder[0], &fptr, folder.size(), &state);
@@ -221,6 +221,8 @@ get_known_folder(const GUID& folderid)
     return folder;
 }
 
+#      ifndef INSTALL
+
 // Usually something like "c:\Users\username\Downloads".
 static
 std::string
@@ -228,6 +230,8 @@ get_download_folder()
 {
     return get_known_folder(FOLDERID_Downloads);
 }
+
+#      endif  // !INSTALL
 
 #    endif // WINRT
 #  else // !_WIN32


### PR DESCRIPTION
Clang 9 (in Visual Studio) complains about a mixed signed-unsigned comparison and an unused function.

- Replace the naked `int` constant -1 by `std::size_t(-1)` with the same codegen as before (no curlies to avoid narrowing).
- Guard the definition of `get_download_folder()` by the same condition as its call-site.

Signed-off-by: Daniela Engert <dani@ngrt.de>