### PR TITLE
#388 add comment on unit test failure

### DIFF
--- a/test/date_test/parse.pass.cpp
+++ b/test/date_test/parse.pass.cpp
@@ -45,6 +45,8 @@ test_a()
         std::istringstream in{"Sun 2016-12-11"};
         sys_days tp;
         in >> parse("%A %F", tp);
+        // this may fail with libstdc++, see https://github.com/HowardHinnant/date/issues/388
+        // possible workaround: compile date.h with -DONLY_C_LOCALE=1
         assert(!in.fail());
         assert(!in.bad());
         assert(!in.eof());


### PR DESCRIPTION
Adding a source code comment to hint that the error is well known is a great idea.
This is what was suggested in https://github.com/HowardHinnant/date/issues/388#issuecomment-421677760 