### PR TITLE
#endf -> #endif after recent change

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -98,7 +98,7 @@ namespace date
 // MSVC
 #  ifndef _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING
 #    define _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING
-#  endf
+#  endif
 #  if _MSC_VER < 1910
 //   before VS2017
 #    define CONSTDATA const


### PR DESCRIPTION
Thanks for fixing the depreciation warning. 
Looks like there is a typo though ~~