### PR TITLE
Use realpath the determine the target of the localtime symlink

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3694,14 +3694,18 @@ tzdb::current_zone() const
             
             auto rp = realpath(timezone, nullptr);
             if (rp == nullptr)
-                throw system_error(errno, system_category(), "realpath() failed");
+                throw system_error(errno, system_category(), R"(realpath("/etc/localtime") failed)");
             
             auto result = string(rp);
             free(rp);
 
-            const size_t pos = result.find(get_tz_dir());
+            const string foldername{"zoneinfo"};
+            const size_t pos = result.find(foldername);
             if (pos != result.npos)
-                result.erase(0, get_tz_dir().size() + 1 + pos);
+                result.erase(0, foldername.size() + 1 + pos);
+            else
+                throw system_error(errno, system_category(), R"(failed to find "zoneinfo-part in path to local timezone file")");
+
             return locate_zone(result);
         }
     }

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3691,12 +3691,13 @@ tzdb::current_zone() const
         CONSTDATA auto timezone = "/etc/localtime";
         if (lstat(timezone, &sb) == 0 && S_ISLNK(sb.st_mode) && sb.st_size > 0) {
             using namespace std;
-            string result;
-            char rp[PATH_MAX+1] = {};
-            if (readlink(timezone, rp, sizeof(rp)-1) > 0)
-                result = string(rp);
-            else
-                throw system_error(errno, system_category(), "readlink() failed");
+            
+            auto rp = realpath(timezone, nullptr);
+            if (rp == nullptr)
+                throw system_error(errno, system_category(), "realpath() failed");
+            
+            auto result = string(rp);
+            free(rp);
 
             const size_t pos = result.find(get_tz_dir());
             if (pos != result.npos)

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3700,7 +3700,7 @@ tzdb::current_zone() const
             free(rp);
 
             const string foldername{"zoneinfo"};
-            const size_t pos = result.find(foldername);
+            const size_t pos = result.rfind(foldername);
             if (pos != result.npos)
                 result.erase(0, foldername.size() + 1 + pos);
             else

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3704,7 +3704,7 @@ tzdb::current_zone() const
             if (pos != result.npos)
                 result.erase(0, foldername.size() + 1 + pos);
             else
-                throw system_error(errno, system_category(), R"(failed to find "zoneinfo-part in path to local timezone file")");
+                throw system_error(errno, system_category(), R"(failed to find "zoneinfo"-part in path to local timezone file)");
 
             return locate_zone(result);
         }


### PR DESCRIPTION
The previous solution would fail, if `/etc/localtime` is a symlink to a symlink to the zone details. Using realpath resolves all potential symlinks and returns directly the path of interest.