### PR TITLE
Make date.h compatible with g++-4.7

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -70,7 +70,9 @@
 
 #ifdef __GNUC__
 # pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wpedantic"
+# if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR > 7)
+#  pragma GCC diagnostic ignored "-Wpedantic"
+# endif
 # if __GNUC__ < 5
    // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
@@ -162,16 +164,16 @@ namespace date
 // durations
 
 using days = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
+    <int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>::type>;
 
 using weeks = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<7>, days::period>>;
+    <int, std::ratio_multiply<std::ratio<7>, days::period>::type>;
 
 using years = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<146097, 400>, days::period>>;
+    <int, std::ratio_multiply<std::ratio<146097, 400>, days::period>::type>;
 
 using months = std::chrono::duration
-    <int, std::ratio_divide<years::period, std::ratio<12>>>;
+    <int, std::ratio_divide<years::period, std::ratio<12>>::type>;
 
 // time_point
 
@@ -404,8 +406,8 @@ public:
     CONSTCD11 explicit operator int() const NOEXCEPT;
     CONSTCD11 bool ok() const NOEXCEPT;
 
-    static CONSTCD11 year min() NOEXCEPT;
-    static CONSTCD11 year max() NOEXCEPT;
+    static CONSTCD11 year min() NOEXCEPT { return year{-32767}; }
+    static CONSTCD11 year max() NOEXCEPT { return year{32767}; }
 };
 
 CONSTCD11 bool operator==(const year& x, const year& y) NOEXCEPT;
@@ -1615,22 +1617,6 @@ bool
 year::ok() const NOEXCEPT
 {
     return y_ != std::numeric_limits<short>::min();
-}
-
-CONSTCD11
-inline
-year
-year::min() NOEXCEPT
-{
-    return year{-32767};
-}
-
-CONSTCD11
-inline
-year
-year::max() NOEXCEPT
-{
-    return year{32767};
 }
 
 CONSTCD11


### PR DESCRIPTION
`date.h` gives the following error when compile with g++-4.7. This PR fixes them.
```
In file included from main.cpp:1:0:
date.h:73:33: warning: unknown option after ‘#pragma GCC diagnostic’ kind [-Wpragmas]
In file included from date.h:45:0,
                 from main.cpp:1:
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono: In instantiation of ‘struct std::chrono::duration<int, std::ratio_multiply<std::ratio<24l>, std::ratio<3600l> > >’:
date.h:168:50:   required from here
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono:227:2: error: static assertion failed: period must be a specialization of ratio
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono: In instantiation of ‘struct std::chrono::duration<int, std::ratio_multiply<std::ratio<146097l, 400l>, std::ratio_multiply<std::ratio<24l>, std::ratio<3600l> > > >’:
date.h:174:34:   required from here
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono:227:2: error: static assertion failed: period must be a specialization of ratio
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono: In instantiation of ‘struct std::chrono::duration<int, std::ratio_divide<std::ratio_multiply<std::ratio<146097l, 400l>, std::ratio_multiply<std::ratio<24l>, std::ratio<3600l> > >, std::ratio<12l> > >’:
date.h:1362:80:   required from here
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono:227:2: error: static assertion failed: period must be a specialization of ratio
In file included from main.cpp:1:0:
date.h:1623:13: error: declaration of ‘static constexpr date::year date::year::min()’ has a different exception specifier
date.h:407:27: error: from previous declaration ‘static constexpr date::year date::year::min() noexcept (true)’
date.h:1631:13: error: declaration of ‘static constexpr date::year date::year::max()’ has a different exception specifier
date.h:408:27: error: from previous declaration ‘static constexpr date::year date::year::max() noexcept (true)’
In file included from date.h:45:0,
                 from main.cpp:1:
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono: In instantiation of ‘struct std::chrono::duration<int, std::ratio_multiply<std::ratio<7l>, std::ratio_multiply<std::ratio<24l>, std::ratio<3600l> > > >’:
date.h:5530:68:   required from here
/usr/lib/gcc/x86_64-redhat-linux/4.7.2/../../../../include/c++/4.7.2/chrono:227:2: error: static assertion failed: period must be a specialization of ratio
```