### PR TITLE
Fix shift overflow warning in clang

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -1152,8 +1152,7 @@ private:
     static const std::intmax_t d1 = R1::den / gcd_d1_d2;
     static const std::intmax_t n2 = R2::num / gcd_n1_n2;
     static const std::intmax_t d2 = R2::den / gcd_d1_d2;
-    static const std::intmax_t max = -((std::intmax_t(1) <<
-                                       (sizeof(std::intmax_t) * CHAR_BIT - 1)) + 1);
+    static const std::intmax_t max = INTMAX_MAX;
 
     template <std::intmax_t Xp, std::intmax_t Yp, bool overflow>
     struct mul    // overflow == false


### PR DESCRIPTION
Compiling in clang results in this warning:
```
date/include/date/date.h:1155:58: warning: signed shift result (0x8000000000000000) sets the sign
bit of the shift expression's type ('std::intmax_t' (aka 'long')) and becomes negative
[-Wshift-sign-overflow]
    static const std::intmax_t max = -((std::intmax_t(1) <<
                                        ~~~~~~~~~~~~~~~~ ^
```
Instead of computing this value, we could use the equivalent macro `INTMAX_MAX` (or `numeric_limits<intmax_t>::max()`) and avoid the warning.

Alternatively, we could perform the computation in a way that avoids overflow: instead of `-((1 << (bits-1)) + 1)` we could do `((1 << (bits-2)) - 1) << 1 + 1`.

I used the macro solution here since it's the least verbose.