### PR TITLE
Honor symbol visibility settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required( VERSION 3.1.0 )
 
+cmake_policy( VERSION 3.12 )
+
 project( date VERSION 2.4.1 )
 
 include( GNUInstallDirs )


### PR DESCRIPTION
When I use date inside a dynamic library I don't want to export date functions as part of my API so I set default visibility to hidden. This change makes date build honor this setting.