### PR TITLE
Fix iOS build: Include ios.mm when compiling to make iOSUtils available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,13 @@ set( HEADER_FILES
 
 add_library( tz ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
 
+# This is  required in order to make iOSUtils available 
+if(IOS) 
+    target_sources(tz PRIVATE ${SOURCE_FOLDER}/ios.mm)
+    add_definitions("-x objective-c++")
+    include_directories(${HEADER_FOLDER}/date)
+endif()
+
 if( USE_SYSTEM_TZ_DB )
 	target_compile_definitions( tz PRIVATE -DUSE_AUTOLOAD=0 )
 	target_compile_definitions( tz PRIVATE -DHAS_REMOTE_API=0 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ add_library( tz ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
 # This is  required in order to make iOSUtils available 
 if(IOS) 
     target_sources(tz PRIVATE ${SOURCE_FOLDER}/ios.mm)
-    add_definitions("-x objective-c++")
-    include_directories(${HEADER_FOLDER}/date)
+    target_compile_options(tz PRIVATE -x objective-c++)
+    target_include_directories(tz PRIVATE ${HEADER_FOLDER}/date)
 endif()
 
 if( USE_SYSTEM_TZ_DB )


### PR DESCRIPTION
When compiling for iOS the ios.mm file is required in order to have implementaions for functions in iOSUtils (otherwise it doesn't link).

Edit: for some reason it identified me as MarsMero ¯\\_(ツ)_/¯