### PR TITLE
Update minimum CMake version for default CXX_STANDARD of 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.1.0 )
+cmake_minimum_required( VERSION 3.8 )
 
 project( date_prj )
 


### PR DESCRIPTION
Currently, the default value for CXX_STANDARD in [the CMakeLists.txt](https://github.com/HowardHinnant/date/blob/master/CMakeLists.txt#L10) is 17. This value is not supported by CMake until version 3.8:

https://cmake.org/cmake/help/v3.7/prop_tgt/CXX_STANDARD.html
https://cmake.org/cmake/help/v3.8/prop_tgt/CXX_STANDARD.html

Attempting to build with CMake versions less than 3.8 result in errors like:
```
CMake Error at CMakeLists.txt:120 (add_executable):
  CXX_STANDARD is set to invalid value '17'
Call Stack (most recent call first):
  CMakeLists.txt:158 (add_pass_tests)
```