### PR TITLE
HAS_UNCAUGHT_EXCEPTIONS now includes C++17

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -137,7 +137,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus > 201703
+#  if __cplusplus >= 201703
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0


### PR DESCRIPTION
The condition was `__cplusplus >= 201703` which excludes C++17.
However, `std::uncaught_exceptions()` was only introduced in C++17.

Fixes #435