### PR TITLE
Fixed deprecation warning on C++17

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -137,7 +137,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus > 201703
+#  if __cplusplus >= 201703
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0


### PR DESCRIPTION
The `HAS_UNCAUGHT_EXCEPTION` macro definition in `date.h` previously used `> 201703` instead of `>= 201703`, which led to deprecation warnings when building for C++ 17. 