### PR TITLE
Test and fixes for zoned_time deduction guides

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -709,6 +709,18 @@ using zoned_seconds = zoned_time<std::chrono::seconds>;
 
 #if HAS_DEDUCTION_GUIDES
 
+namespace detail
+{
+   template<typename TimeZonePtrOrName>
+   using time_zone_representation =
+       std::conditional_t
+       <
+           std::is_convertible<TimeZonePtrOrName, std::string_view>::value,
+           time_zone const*,
+           std::remove_cv_t<std::remove_reference_t<TimeZonePtrOrName>>
+       >;
+}
+
 zoned_time()
     -> zoned_time<std::chrono::seconds>;
 
@@ -717,44 +729,20 @@ zoned_time(sys_time<Duration>)
     -> zoned_time<std::common_type_t<Duration, std::chrono::seconds>>;
 
 template <class TimeZonePtrOrName>
-zoned_time(TimeZonePtrOrName)
-    -> zoned_time<std::chrono::seconds,
-                  std::conditional_t
-                  <
-                      std::is_convertible<TimeZonePtrOrName, std::string_view>::value,
-                      time_zone const*,
-                      TimeZonePtrOrName
-                  >>;
+zoned_time(TimeZonePtrOrName&&)
+    -> zoned_time<std::chrono::seconds, detail::time_zone_representation<TimeZonePtrOrName>>;
 
 template <class TimeZonePtrOrName, class Duration>
-zoned_time(TimeZonePtrOrName, sys_time<Duration>)
-    -> zoned_time<std::common_type_t<Duration, std::chrono::seconds>,
-                  std::conditional_t
-                  <
-                      std::is_convertible<TimeZonePtrOrName, std::string_view>::value,
-                      time_zone const*,
-                      TimeZonePtrOrName
-                  >>;
+zoned_time(TimeZonePtrOrName&&, sys_time<Duration>)
+    -> zoned_time<std::common_type_t<Duration, std::chrono::seconds>, detail::time_zone_representation<TimeZonePtrOrName>>;
 
 template <class TimeZonePtrOrName, class Duration>
-zoned_time(TimeZonePtrOrName, local_time<Duration>, choose = choose::earliest)
-    -> zoned_time<std::common_type_t<Duration, std::chrono::seconds>,
-                  std::conditional_t
-                  <
-                      std::is_convertible<TimeZonePtrOrName, std::string_view>::value,
-                      time_zone const*,
-                      TimeZonePtrOrName
-                  >>;
+zoned_time(TimeZonePtrOrName&&, local_time<Duration>, choose = choose::earliest)
+    -> zoned_time<std::common_type_t<Duration, std::chrono::seconds>, detail::time_zone_representation<TimeZonePtrOrName>>;
 
 template <class Duration, class TimeZonePtrOrName, class TimeZonePtr2>
-zoned_time(TimeZonePtrOrName, zoned_time<Duration, TimeZonePtr2>, choose = choose::earliest)
-    -> zoned_time<std::common_type_t<Duration, std::chrono::seconds>,
-                  std::conditional_t
-                  <
-                      std::is_convertible<TimeZonePtrOrName, std::string_view>::value,
-                      time_zone const*,
-                      TimeZonePtrOrName
-                  >>;
+zoned_time(TimeZonePtrOrName&&, zoned_time<Duration, TimeZonePtr2>, choose = choose::earliest)
+    -> zoned_time<std::common_type_t<Duration, std::chrono::seconds>, detail::time_zone_representation<TimeZonePtrOrName>>;
 
 #endif  // HAS_DEDUCTION_GUIDES
 

--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -151,6 +151,15 @@ enum class choose {earliest, latest};
 namespace detail
 {
     struct undocumented;
+
+    template<typename T>
+    struct nodeduct
+    {
+       using type = T;
+    };
+
+    template<typename T>
+    using nodeduct_t = typename nodeduct<T>::type;
 }
 
 struct sys_info
@@ -447,7 +456,7 @@ public:
                       sys_time<Duration>
                   >::value
               >::type>
-        zoned_time(std::string_view name, const sys_time<Duration>& st);
+        zoned_time(std::string_view name, detail::nodeduct_t<const sys_time<Duration>&> st);
 
     template <class T = TimeZonePtr,
               class = typename std::enable_if
@@ -459,7 +468,7 @@ public:
                       local_time<Duration>
                   >::value
               >::type>
-        zoned_time(std::string_view name, const local_time<Duration>& tp);
+        zoned_time(std::string_view name, detail::nodeduct_t<const local_time<Duration>&> tp);
 
     template <class T = TimeZonePtr,
               class = typename std::enable_if
@@ -472,7 +481,7 @@ public:
                       choose
                   >::value
               >::type>
-        zoned_time(std::string_view name,   const local_time<Duration>& tp, choose c);
+        zoned_time(std::string_view name, detail::nodeduct_t<const local_time<Duration>&> tp, choose c);
 
     template <class Duration2, class TimeZonePtr2, class T = TimeZonePtr,
               class = typename std::enable_if
@@ -1448,7 +1457,7 @@ template <class Duration, class TimeZonePtr>
 template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
-                                              const sys_time<Duration>& st)
+                                              detail::nodeduct_t<const sys_time<Duration>&> st)
     : zoned_time(zoned_traits<TimeZonePtr>::locate_zone(name), st)
     {}
 
@@ -1456,7 +1465,7 @@ template <class Duration, class TimeZonePtr>
 template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
-                                              const local_time<Duration>& t)
+                                              detail::nodeduct_t<const local_time<Duration>&> t)
     : zoned_time(zoned_traits<TimeZonePtr>::locate_zone(name), t)
     {}
 
@@ -1464,7 +1473,7 @@ template <class Duration, class TimeZonePtr>
 template <class T, class>
 inline
 zoned_time<Duration, TimeZonePtr>::zoned_time(std::string_view name,
-                                              const local_time<Duration>& t, choose c)
+                                              detail::nodeduct_t<const local_time<Duration>&> t, choose c)
     : zoned_time(zoned_traits<TimeZonePtr>::locate_zone(name), t, c)
     {}
 

--- a/test/tz_test/OffsetZone.h
+++ b/test/tz_test/OffsetZone.h
@@ -1,0 +1,73 @@
+#ifndef OFFSET_ZONE_H
+#define OFFSET_ZONE_H
+
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Howard Hinnant
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Test custom time zone support
+
+#include "tz.h"
+
+class OffsetZone
+{
+    std::chrono::minutes offset_;
+
+public:
+    explicit OffsetZone(std::chrono::minutes offset)
+        : offset_{offset}
+        {}
+
+    template <class Duration>
+        auto
+        to_local(date::sys_time<Duration> tp) const
+        {
+            using namespace date;
+            using namespace std::chrono;
+            using LT = local_time<std::common_type_t<Duration, minutes>>;
+            return LT{(tp + offset_).time_since_epoch()};
+        }
+
+    template <class Duration>
+        auto
+        to_sys(date::local_time<Duration> tp, date::choose = date::choose::earliest) const
+        {
+            using namespace date;
+            using namespace std::chrono;
+            using ST = sys_time<std::common_type_t<Duration, minutes>>;
+            return ST{(tp - offset_).time_since_epoch()};
+        }
+
+    template <class Duration>
+        date::sys_info
+        get_info(date::sys_time<Duration> st) const
+        {
+            using namespace date;
+            using namespace std::chrono;
+            return {sys_seconds::min(), sys_seconds::max(), offset_,
+                    minutes{0}, offset_ >= minutes{0} ? "+" + date::format("%H%M", offset_)
+                                          : "-" + date::format("%H%M", -offset_)};
+        }
+
+    const OffsetZone* operator->() const {return this;}
+};
+
+#endif // OFFSET_ZONE_H

--- a/test/tz_test/OffsetZone.pass.cpp
+++ b/test/tz_test/OffsetZone.pass.cpp
@@ -23,50 +23,7 @@
 // Test custom time zone support
 
 #include "tz.h"
-
-class OffsetZone
-{
-    std::chrono::minutes offset_;
-
-public:
-    explicit OffsetZone(std::chrono::minutes offset)
-        : offset_{offset}
-        {}
-
-    template <class Duration>
-        auto
-        to_local(date::sys_time<Duration> tp) const
-        {
-            using namespace date;
-            using namespace std::chrono;
-            using LT = local_time<std::common_type_t<Duration, minutes>>;
-            return LT{(tp + offset_).time_since_epoch()};
-        }
-
-    template <class Duration>
-        auto
-        to_sys(date::local_time<Duration> tp) const
-        {
-            using namespace date;
-            using namespace std::chrono;
-            using ST = sys_time<std::common_type_t<Duration, minutes>>;
-            return ST{(tp - offset_).time_since_epoch()};
-        }
-
-    template <class Duration>
-        date::sys_info
-        get_info(date::sys_time<Duration> st) const
-        {
-            using namespace date;
-            using namespace std::chrono;
-            return {sys_seconds::min(), sys_seconds::max(), offset_,
-                    minutes{0}, offset_ >= minutes{0} ? "+" + date::format("%H%M", offset_)
-                                          : "-" + date::format("%H%M", -offset_)};
-        }
-
-    const OffsetZone* operator->() const {return this;}
-};
-
+#include "OffsetZone.h"
 #include <cassert>
 
 int

--- a/test/tz_test/zoned_time_deduction.pass.cpp
+++ b/test/tz_test/zoned_time_deduction.pass.cpp
@@ -127,6 +127,15 @@ private:
   std::string ms;
 };
 
+struct OnlyLValueString
+{
+  OnlyLValueString(std::string s) : ms(std::move(s)) {}
+
+  operator std::string_view() & { return ms; }
+
+private:
+  std::string ms;
+};
 
 #endif  // HAS_DEDUCTION_GUIDES
 
@@ -223,6 +232,14 @@ main()
        testDeductionFrom<OffsetZone>(tz);
        testDeductionFrom<OffsetZone>(to_const(tz));
        testDeductionFrom<OffsetZone>(std::move(tz));
+    }
+
+    // OnlyLValue
+    {
+       OnlyLValueString tz("Europe/Warsaw");
+       testDeductionFrom<time_zone const*>(tz);
+       //testDeductionFrom<time_zone const*>(to_const(tz));
+       //testDeductionFrom<time_zone const*>(std::move(tz));
     }
 
 #endif  // HAS_DEDUCTION_GUIDES

--- a/test/tz_test/zoned_time_deduction.pass.cpp
+++ b/test/tz_test/zoned_time_deduction.pass.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "tz.h"
+#include "OffsetZone.h"
 #include <cassert>
 #include <type_traits>
 #include <string>
@@ -214,6 +215,14 @@ main()
        testDeductionFrom<time_zone const*>(tz);
        testDeductionFrom<time_zone const*>(to_const(tz));
        testDeductionFrom<time_zone const*>(std::move(tz));
+    }
+
+    // custom time zone
+    {
+       OffsetZone tz(minutes(45));
+       testDeductionFrom<OffsetZone>(tz);
+       testDeductionFrom<OffsetZone>(to_const(tz));
+       testDeductionFrom<OffsetZone>(std::move(tz));
     }
 
 #endif  // HAS_DEDUCTION_GUIDES

--- a/test/tz_test/zoned_time_deduction.pass.cpp
+++ b/test/tz_test/zoned_time_deduction.pass.cpp
@@ -1,0 +1,220 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 Tomasz Kamiński
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "tz.h"
+#include <cassert>
+#include <type_traits>
+#include <string>
+
+#if HAS_DEDUCTION_GUIDES
+#include <string_view>
+
+template<typename TimeZonePtr, typename Source>
+void testDeductionFrom(Source&& s)
+{
+    using namespace date;
+    using namespace std::chrono;
+
+    // No time point
+    {
+        zoned_time zt(std::forward<Source>(s));
+        static_assert(std::is_same<decltype(zt), zoned_time<seconds, TimeZonePtr>>::value, "");
+    }
+
+    // sys_time
+    {
+        sys_days sd(2017_y/feb/20);
+        zoned_time ztd(std::forward<Source>(s), sd);
+        static_assert(std::is_same<decltype(ztd), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        sys_time<seconds> ss(sd);
+        zoned_time zts(std::forward<Source>(s), ss);
+        static_assert(std::is_same<decltype(zts), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        sys_time<milliseconds> sms(ss);
+        zoned_time ztms(std::forward<Source>(s), sms);
+        static_assert(std::is_same<decltype(ztms), zoned_time<milliseconds, TimeZonePtr>>::value, "");
+    }
+
+    // local_time
+    {
+        local_days ld(2017_y/feb/20);
+        zoned_time ztd(std::forward<Source>(s), ld);
+        static_assert(std::is_same<decltype(ztd), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        local_time<seconds> ls(ld);
+        zoned_time zts(std::forward<Source>(s), ls);
+        static_assert(std::is_same<decltype(zts), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        local_time<milliseconds> lms(ls);
+        zoned_time ztms(std::forward<Source>(s), lms);
+        static_assert(std::is_same<decltype(ztms), zoned_time<milliseconds, TimeZonePtr>>::value, "");
+    }
+
+    // local_time, choose
+    {
+        local_days ld(2017_y/feb/20);
+        zoned_time ztd(std::forward<Source>(s), ld, choose::earliest);
+        static_assert(std::is_same<decltype(ztd), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        local_time<seconds> ls(ld);
+        zoned_time zts(std::forward<Source>(s), ls, choose::earliest);
+        static_assert(std::is_same<decltype(zts), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        local_time<milliseconds> lms(ls);
+        zoned_time ztms(std::forward<Source>(s), lms, choose::earliest);
+        static_assert(std::is_same<decltype(ztms), zoned_time<milliseconds, TimeZonePtr>>::value, "");
+    }
+
+    // zoned_time
+    {
+        zoned_time<days> zd(sys_days(2017_y/feb/20));
+        zoned_time ztd(std::forward<Source>(s), zd);
+        static_assert(std::is_same<decltype(ztd), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        zoned_time<seconds> zs(zd);
+        zoned_time zts(std::forward<Source>(s), zs);
+        static_assert(std::is_same<decltype(zts), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        zoned_time<milliseconds> zms(zs);
+        zoned_time ztms(std::forward<Source>(s), zms);
+        static_assert(std::is_same<decltype(ztms), zoned_time<milliseconds, TimeZonePtr>>::value, "");
+    }
+
+    // zoned_time, choose
+    {
+        zoned_time<days> zd(sys_days(2017_y/feb/20));
+        zoned_time ztd(std::forward<Source>(s), zd, choose::earliest);
+        static_assert(std::is_same<decltype(ztd), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        zoned_time<seconds> zs(zd);
+        zoned_time zts(std::forward<Source>(s), zs, choose::earliest);
+        static_assert(std::is_same<decltype(zts), zoned_time<seconds, TimeZonePtr>>::value, "");
+
+        zoned_time<milliseconds> zms(zs);
+        zoned_time ztms(std::forward<Source>(s), zms, choose::earliest);
+        static_assert(std::is_same<decltype(ztms), zoned_time<milliseconds, TimeZonePtr>>::value, "");
+    }
+}
+
+struct MyString
+{
+  MyString(std::string s) : ms(std::move(s)) {}
+
+  operator std::string_view() const { return ms; }
+
+private:
+  std::string ms;
+};
+
+
+#endif  // HAS_DEDUCTION_GUIDES
+
+template<typename T>
+T const& to_const(T& t) { return t; }
+
+
+int
+main()
+{
+    using namespace date;
+    using namespace std::chrono;
+
+#if HAS_DEDUCTION_GUIDES
+    //  no arguments
+    {
+        zoned_time zt{};
+        static_assert(std::is_same<decltype(zt), zoned_time<seconds>>::value, "");
+    } 
+
+    // zoned_time
+    {
+        zoned_time<days> zd(sys_days(2017_y/feb/20));
+        zoned_time ztd(zd);
+        static_assert(std::is_same<decltype(ztd), zoned_time<days>>::value, "");
+
+        zoned_time<seconds> zs(zd);
+        zoned_time zts(zs);
+        static_assert(std::is_same<decltype(zts), zoned_time<seconds>>::value, "");
+
+        zoned_time<milliseconds> zms(zs);
+        zoned_time ztms(zms);
+        static_assert(std::is_same<decltype(ztms), zoned_time<milliseconds>>::value, "");
+    }
+
+    // sys_time
+    {
+        sys_days sd(2017_y/feb/20);
+        zoned_time ztd(sd);
+        static_assert(std::is_same<decltype(ztd), zoned_time<seconds>>::value, "");
+
+        sys_time<seconds> ss(sd);
+        zoned_time zts(ss);
+        static_assert(std::is_same<decltype(zts), zoned_time<seconds>>::value, "");
+
+        sys_time<milliseconds> sms(ss);
+        zoned_time ztms(sms);
+        static_assert(std::is_same<decltype(ztms), zoned_time<milliseconds>>::value, "");
+    }
+
+    // time_zone const*
+    {
+       time_zone const* tz = current_zone();
+       testDeductionFrom<time_zone const*>(tz);
+       testDeductionFrom<time_zone const*>(to_const(tz));
+       testDeductionFrom<time_zone const*>(std::move(tz));
+    }
+
+    // char const*
+    {
+       char const* tz = "Europe/Warsaw";
+       testDeductionFrom<time_zone const*>(tz);
+       testDeductionFrom<time_zone const*>(to_const(tz));
+       testDeductionFrom<time_zone const*>(std::move(tz));
+    }
+
+    // std::string
+    {
+       std::string tz = "Europe/Warsaw";
+       testDeductionFrom<time_zone const*>(tz);
+       testDeductionFrom<time_zone const*>(to_const(tz));
+       testDeductionFrom<time_zone const*>(std::move(tz));
+    }
+
+    // std::string_view
+    {
+       std::string_view tz = "Europe/Warsaw";
+       testDeductionFrom<time_zone const*>(tz);
+       testDeductionFrom<time_zone const*>(to_const(tz));
+       testDeductionFrom<time_zone const*>(std::move(tz));
+    }
+
+    // MyString
+    {
+       MyString tz("Europe/Warsaw");
+       testDeductionFrom<time_zone const*>(tz);
+       testDeductionFrom<time_zone const*>(to_const(tz));
+       testDeductionFrom<time_zone const*>(std::move(tz));
+    }
+
+#endif  // HAS_DEDUCTION_GUIDES
+}


### PR DESCRIPTION
This implements a bunch of test for the zoned_time deduction guides.
This test showed up that a few fixes are necessary:
1) `string_view` constructor still produces better candidates, so the resolution is not reduced
2) we mishandle types that are convertible to `string_view` only as rvalue (suggested by Tim Song)