### PR TITLE
Fix issue #338: Fix _cplusplus test for C++17 to be correct.  This prevents users fro…

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -137,7 +137,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus > 201703
+#  if __cplusplus >= 201703
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0


### PR DESCRIPTION
…m having to set the HAS_UNCAUGHT_EXCEPTIONS before including date.h include file.