### PR TITLE
set library version to 2.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required( VERSION 3.1.0 )
 
 project( date_prj )
-set(DATE_LIBRARY_VERSION 1.0.0)
+set(DATE_LIBRARY_VERSION 2.4.1)
 
 include( GNUInstallDirs )
 


### PR DESCRIPTION
In my initial PR, I've set version to 1.0.0 cause was not sure which one is right now correct. But you already merged it, so I'm adding this small fix to sett version to the last release you have. 