### PR TITLE
Enable CI build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,66 @@
+language: cpp
+
+matrix:
+  include:
+   
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+
+    - os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+      env:
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+
+before_install:
+    - eval "${MATRIX_EVAL}"
+
+script: 
+  - mkdir -p build
+  - cd build
+  - cmake -DENABLE_DATE_TESTING=ON -DBUILD_SHARED_LIBS=ON -DCOMPILE_WITH_C_LOCALE=ON ..
+  - make -j$(nproc)
+  - make testit -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ option( USE_TZ_DB_IN_DOT "Save the timezone database in the current folder" OFF 
 option( BUILD_SHARED_LIBS  "Build a shared version of library" OFF )
 option( ENABLE_DATE_TESTING "Enable unit tests" ON )
 option( DISABLE_STRING_VIEW "Disable string view" OFF )
+option( COMPILE_WITH_C_LOCALE "pass -DONLY_C_LOCALE=1 to copiler")
+
+if(COMPILE_WITH_C_LOCALE)
+    #To workaround libstdc++ issue https://github.com/HowardHinnant/date/issues/388
+    add_definitions(-DONLY_C_LOCALE=1)
+endif()
 
 function( print_option OPT )
 	if ( NOT DEFINED PRINT_OPTION_CURR_${OPT} OR ( NOT PRINT_OPTION_CURR_${OPT} STREQUAL ${OPT} ) )

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Date
 
+[![Build Status](https://travis-ci.org/miketsukerman/date.svg?branch=add-continues-integration)](https://travis-ci.org/miketsukerman/date)
 [![Join the chat at https://gitter.im/HowardHinnant/date](https://badges.gitter.im/HowardHinnant/date.svg)](https://gitter.im/HowardHinnant/date?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ---


### PR DESCRIPTION
The first approximation of build matrix for date library. For now, It includes only Linux targets.  
On those targets, build goes fine:
```
Ubuntu 16.04 with gcc 7
Ubuntu 16.04 with gcc 8
Ubuntu 16.04 with gcc 9   

Ubuntu 18.04 with gcc 7

Ubuntu 18.05 with clang 6
```
I've checked on a couple of others. For example, with gcc 4 to 6, there are issues. Also with macOS targets. 

The question is what minimal amount of configurations we need for testing? I mean what operating systems and compiler versions.
