### PR TITLE
Fix MSVC C++ version detection

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -137,7 +137,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus > 201703
+#  if __cplusplus > 201703 || (defined(_MSVC_LANG) && _MSVC_LANG > 201703L)
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0
@@ -145,7 +145,7 @@ namespace date
 #endif  // HAS_UNCAUGHT_EXCEPTIONS
 
 #ifndef HAS_VOID_T
-#  if __cplusplus >= 201703
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #    define HAS_VOID_T 1
 #  else
 #    define HAS_VOID_T 0


### PR DESCRIPTION
Currently, only `std::string_view` support is detected based on the C++ standard version set by either CMake or the user, while `std::uncaught_exceptions()` and `std::void_t` are always disabled in MSVC even if the compiler supports it and the correct C++ standard version is selected.

This PR fixes MSVC C++ version detection for `HAS_UNCAUGHT_EXCEPTIONS` and `HAS_VOID_T`.

Tested with VS2015, VS2017 and VS2019.

Abbreviations: HAS_(**S**)TRING_VIEW / HAS_UNCAUGHT_(**E**)XCEPTIONS / HAS_(**V**)OID_T

| IDE    | MSVC  | /std:c++14 | /std:c++17 | /std:c++latest
|--------|-------|------------|------------|---------------
| VS2015 | 19.00 | -/-/-      |            | -/-/-      
| VS2017 | 19.16 | -/-/-      | S/E/V      | S/E/V
| VS2019 | 19.22 | -/-/-      | S/E/V      | S/E/V

How to reproduce in godbolt: https://godbolt.org/z/oENEp-

```cpp
#include <date/date.h>

#if HAS_STRING_VIEW != 1
  #error <string_view> not supported
#endif

#if HAS_UNCAUGHT_EXCEPTIONS != 1
  #error std::uncaught_exceptions() not supported
#endif

#if HAS_VOID_T != 1
  #error std::void_t not supported
#endif

int main() {
}
```