### PR TITLE
Add possibility to remove compilation of current_zone for embedded systems

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -288,7 +288,9 @@ DATE_API const time_zone* locate_zone(std::string_view tz_name);
 DATE_API const time_zone* locate_zone(const std::string& tz_name);
 #endif
 
+#ifndef TZDB_NO_CURRENT_ZONE
 DATE_API const time_zone* current_zone();
+#endif
 
 template <class T>
 struct zoned_traits
@@ -1200,7 +1202,10 @@ struct tzdb
 #else
     const time_zone* locate_zone(const std::string& tz_name) const;
 #endif
+
+#ifndef TZDB_NO_CURRENT_ZONE
     const time_zone* current_zone() const;
+#endif
 };
 
 using TZ_DB = tzdb;

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3670,7 +3670,7 @@ tzdb::current_zone() const
 }
 
 #else  // !_WIN32
-
+# ifndef TZDB_NO_CURRENT_ZONE
 const time_zone*
 tzdb::current_zone() const
 {
@@ -3807,14 +3807,16 @@ tzdb::current_zone() const
     }
     throw std::runtime_error("Could not get current timezone");
 }
-
+# endif
 #endif  // !_WIN32
 
+#ifndef TZDB_NO_CURRENT_ZONE
 const time_zone*
 current_zone()
 {
     return get_tzdb().current_zone();
 }
+#endif
 
 }  // namespace date
 


### PR DESCRIPTION
On embedded systems there is often no filesystem. These things are stored somewhere else and it is easier to feed this directly or create the zone by itself rather than implementing a filesystem. With this little help one can compile the stuff without implementing the current_zone() function. The function can be easily replaced by something specific for the system. If there are better suggestions, I am open for discussion.