### PR TITLE
Work around for NVCC compiler bug

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -158,6 +158,17 @@ namespace date
 #  undef sun
 #endif
 
+// Work around for a NVCC compiler bug which causes it to fail
+// to compile std::ratio_{multiply,divide} when used directly
+// in the std::chrono::duration template instantiations below
+namespace detail {
+template <typename R1, typename R2>
+using ratio_multiply = decltype(std::ratio_multiply<R1, R2>{});
+
+template <typename R1, typename R2>
+using ratio_divide = decltype(std::ratio_divide<R1, R2>{});
+}  // namespace detail
+
 //-----------+
 // Interface |
 //-----------+
@@ -165,16 +176,16 @@ namespace date
 // durations
 
 using days = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>::type>;
+    <int, detail::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
 
 using weeks = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<7>, days::period>::type>;
+    <int, detail::ratio_multiply<std::ratio<7>, days::period>>;
 
 using years = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<146097, 400>, days::period>::type>;
+    <int, detail::ratio_multiply<std::ratio<146097, 400>, days::period>>;
 
 using months = std::chrono::duration
-    <int, std::ratio_divide<years::period, std::ratio<12>>::type>;
+    <int, detail::ratio_divide<years::period, std::ratio<12>>>;
 
 // time_point
 

--- a/include/date/islamic.h
+++ b/include/date/islamic.h
@@ -39,10 +39,10 @@ using days = date::days;
 using weeks = date::weeks;
 
 using years = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<10631, 30>, days::period>>;
+    <int, date::detail::ratio_multiply<std::ratio<10631, 30>, days::period>>;
 
 using months = std::chrono::duration
-    <int, std::ratio_divide<years::period, std::ratio<12>>>;
+    <int, date::detail::ratio_divide<years::period, std::ratio<12>>>;
 
 // time_point
 

--- a/include/date/julian.h
+++ b/include/date/julian.h
@@ -39,10 +39,10 @@ using days = date::days;
 using weeks = date::weeks;
 
 using years = std::chrono::duration
-    <int, std::ratio_multiply<std::ratio<1461, 4>, days::period>>;
+    <int, date::detail::ratio_multiply<std::ratio<1461, 4>, days::period>>;
 
 using months = std::chrono::duration
-    <int, std::ratio_divide<years::period, std::ratio<12>>>;
+    <int, date::detail::ratio_divide<years::period, std::ratio<12>>>;
 
 // time_point
 

--- a/test/date_test/detail/decimal_format_seconds.pass.cpp
+++ b/test/date_test/detail/decimal_format_seconds.pass.cpp
@@ -55,12 +55,12 @@
 #include <type_traits>
 
 using fortnights = std::chrono::duration<date::weeks::rep,
-                                         std::ratio_multiply<std::ratio<2>,
-                                                             date::weeks::period>>;
+                                         date::detail::ratio_multiply<std::ratio<2>,
+                                                                      date::weeks::period>>;
 
 using microfortnights = std::chrono::duration<std::int64_t,
-                                              std::ratio_multiply<fortnights::period,
-                                                                  std::micro>>;
+                                              date::detail::ratio_multiply<fortnights::period,
+                                                                           std::micro>>;
 
 int
 main()

--- a/test/date_test/format/range.pass.cpp
+++ b/test/date_test/format/range.pass.cpp
@@ -27,12 +27,12 @@
 #include <type_traits>
 
 using fortnights = std::chrono::duration<date::weeks::rep,
-                                         std::ratio_multiply<std::ratio<2>,
-                                                             date::weeks::period>>;
+                                         date::detail::ratio_multiply<std::ratio<2>,
+                                                                      date::weeks::period>>;
 
 using microfortnights = std::chrono::duration<std::int64_t,
-                                              std::ratio_multiply<fortnights::period,
-                                                                  std::micro>>;
+                                              date::detail::ratio_multiply<fortnights::period,
+                                                                           std::micro>>;
 
 int
 main()

--- a/test/date_test/multi_year_duration_addition.pass.cpp
+++ b/test/date_test/multi_year_duration_addition.pass.cpp
@@ -72,8 +72,8 @@ main()
     using namespace date;
     using namespace std::chrono;
 
-    using decades = duration<int, std::ratio_multiply<std::ratio<10>, years::period>>;
-    using decamonths = duration<int, std::ratio_multiply<std::ratio<10>, months::period>>;
+    using decades = duration<int, date::detail::ratio_multiply<std::ratio<10>, years::period>>;
+    using decamonths = duration<int, date::detail::ratio_multiply<std::ratio<10>, months::period>>;
 
     constexpr months one_month{1};
     constexpr years one_year{1};

--- a/test/date_test/time_of_day_microfortnights.pass.cpp
+++ b/test/date_test/time_of_day_microfortnights.pass.cpp
@@ -57,12 +57,12 @@
 #include <type_traits>
 
 using fortnights = std::chrono::duration<date::weeks::rep,
-                                         std::ratio_multiply<std::ratio<2>,
-                                                             date::weeks::period>>;
+                                         date::detail::ratio_multiply<std::ratio<2>,
+                                                                      date::weeks::period>>;
 
 using microfortnights = std::chrono::duration<std::int64_t,
-                                              std::ratio_multiply<fortnights::period,
-                                                                  std::micro>>;
+                                              date::detail::ratio_multiply<fortnights::period,
+                                                                           std::micro>>;
 
 int
 main()


### PR DESCRIPTION
The NVCC compiler fails to compile the date library due
to a compiler bug which causes it to emit an error when
directly using std::ratio_{multiply,divide} in the template
instantiations for std::duration. This PR works around the
issue by introducing custom ratio_{multiply,divide} which
delegate to the standard library templates