### PR TITLE
Fixed a typo in CMakeLists.txt: USE_AUTOLOAD => AUTO_DOWNLOAD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if( BUILD_TZ_LIB )
         $<INSTALL_INTERFACE:include> )
     target_compile_definitions( tz
         PRIVATE
-            USE_AUTOLOAD=$<IF:$<BOOL:${USE_SYSTEM_TZ_DB}>,0,1>
+            AUTO_DOWNLOAD=$<IF:$<BOOL:${USE_SYSTEM_TZ_DB}>,0,1>
             HAS_REMOTE_API=$<IF:$<BOOL:${USE_SYSTEM_TZ_DB}>,0,1>
             $<$<AND:$<BOOL:${WIN32}>,$<BOOL:${BUILD_SHARED_LIBS}>>:DATE_BUILD_DLL=1>
             $<$<BOOL:${USE_TZ_DB_IN_DOT}>:INSTALL=.>


### PR DESCRIPTION
USE_AUTOLOAD wasn't used anywhere else in date's sources. AUTO_DOWNLOAD
is used in .cpp/.h files while never mentioned in CMakeLists.txt.
Must have been a typo.