### PR TITLE
Update Date.h

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -1564,7 +1564,7 @@ inline
 month
 operator+(const month& x, const months& y) NOEXCEPT
 {
-    auto const mu = static_cast<long long>(static_cast<unsigned>(x)) + (y.count() - 1);
+    auto const mu = static_cast<long long>(static_cast<unsigned>(x)) + ((int64_t)y.count() - 1);
     auto const yr = (mu >= 0 ? mu : mu-11) / 12;
     return month{static_cast<unsigned>(mu - yr * 12 + 1)};
 }

--- a/include/date/date.h
+++ b/include/date/date.h
@@ -1564,7 +1564,7 @@ inline
 month
 operator+(const month& x, const months& y) NOEXCEPT
 {
-    auto const mu = static_cast<long long>(static_cast<unsigned>(x)) + (int64_t)y.count() - 1;
+    auto const mu = static_cast<long long>(static_cast<unsigned>(x)) + y.count() - 1;
     auto const yr = (mu >= 0 ? mu : mu-11) / 12;
     return month{static_cast<unsigned>(mu - yr * 12 + 1)};
 }

--- a/include/date/date.h
+++ b/include/date/date.h
@@ -1564,7 +1564,7 @@ inline
 month
 operator+(const month& x, const months& y) NOEXCEPT
 {
-    auto const mu = static_cast<long long>(static_cast<unsigned>(x)) + ((int64_t)y.count() - 1);
+    auto const mu = static_cast<long long>(static_cast<unsigned>(x)) + (int64_t)y.count() - 1;
     auto const yr = (mu >= 0 ? mu : mu-11) / 12;
     return month{static_cast<unsigned>(mu - yr * 12 + 1)};
 }


### PR DESCRIPTION
Arithmetic overflow: Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Casting the value to the wider type before calling operator '-' to avoid overflow.