### PR TITLE
Update date.h

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -1718,7 +1718,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year& y)
     detail::save_ostream<CharT, Traits> _(os);
     os.fill('0');
     os.flags(std::ios::dec | std::ios::internal);
-    os.width(4 + (y < year{0}));
+    os.width(4 + int64_t(y < year{0}));
     os.imbue(std::locale::classic());
     os << static_cast<int>(y);
     if (!y.ok())

--- a/include/date/date.h
+++ b/include/date/date.h
@@ -1718,7 +1718,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year& y)
     detail::save_ostream<CharT, Traits> _(os);
     os.fill('0');
     os.flags(std::ios::dec | std::ios::internal);
-    os.width(4 + int64_t(y < year{0}));
+    os.width(4 + uint64_t(y < year{0}));
     os.imbue(std::locale::classic());
     os << static_cast<int>(y);
     if (!y.ok())


### PR DESCRIPTION
Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Casting the value to the wider type before calling operator '+' to avoid overflow.