### PR TITLE
CMakeLists.txt: output date.pc for pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,15 @@ if( BUILD_TZ_LIB )
     endif( )
 endif( )
 
+if ( BUILD_TZ_LIB )
+  # Cflags: -I${includedir} @TZ_COMPILE_DEFINITIONS@
+  set( TZ_COMPILE_DEFINITIONS "$<IF:$<TARGET_EXISTS:tz>,-D$<JOIN:$<TARGET_PROPERTY:tz,INTERFACE_COMPILE_DEFINITIONS>, -D>,>" )
+  configure_file(date.pc.in date.pc.cf @ONLY)
+  file( GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/date.pc"
+    INPUT "${CMAKE_CURRENT_BINARY_DIR}/date.pc.cf" )
+
+endif( )
+
 #[===================================================================[
    installation
 #]===================================================================]
@@ -170,6 +179,12 @@ install( EXPORT dateConfig
 install (
   FILES cmake/dateConfig.cmake "${version_config}"
   DESTINATION ${CONFIG_LOC})
+
+if ( BUILD_TZ_LIB )
+  install(
+    FILES ${CMAKE_BINARY_DIR}/date.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif( )
 
 #[===================================================================[
    testing

--- a/date.pc.in
+++ b/date.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_BINDIR@
+libdir=@CMAKE_INSTALL_LIB@
+includedir=@CMAKE_INSTALL_INCLUDE@
+
+Name: date
+Description: A date and time library based on the C++11/14/17 <chrono> header
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -ltz
+Cflags: -I${includedir} @TZ_COMPILE_DEFINITIONS@


### PR DESCRIPTION
This fixes #537 by adding a `date.pc.in` that is processed (to `date.pc`) and installed by cmake to the appropriate directory for pkg-config.

This patch, for example, allows me to package `date` for Nix and thus build the newest versions of `Waybar`.

Thanks!