### PR TITLE
Fix uncaught exceptions availability check

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -138,7 +138,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus > 201703 || (defined(_MSVC_LANG) && _MSVC_LANG > 201703L)
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0


### PR DESCRIPTION
I am building this library with `gcc (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008` with C++17 and I got lots of compilation warnings, this check seems to be incorrect.