### PR TITLE
Throw a runtime error instead of terminating

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -1447,7 +1447,11 @@ find_previous_rule(const Rule* r, date::year y)
     if (y == r->starting_year())
     {
         if (r == &rules.front() || r->name() != r[-1].name())
-            std::terminate();  // never called with first rule
+        {
+            throw std::runtime_error("find_previous_rule called but no previous rule");
+            Rule *noRule;
+            return {noRule, date::year::min()};
+        }
         --r;
         if (y == r->starting_year())
             return {r, y};


### PR DESCRIPTION

Elsewhere in this file if something goes wrong we throw a runtime error. If we also do that here instead of calling std::terminate we can catch it and fix the calling code.