### PR TITLE
HAS_UNCAUGHT_EXCEPTIONS not defined

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -138,7 +138,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus > 201703 || (defined(_MSVC_LANG) && _MSVC_LANG > 201703L)
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0


### PR DESCRIPTION
`HAS_UNCAUGHT_EXCEPTIONS` must be defined as 1 for C++17 (201703). See examples at https://github.com/HowardHinnant/date/blob/master/include/date/date.h#L36 and https://github.com/HowardHinnant/date/blob/master/include/date/date.h#L148.

Documentation:
- https://en.cppreference.com/w/cpp/error/uncaught_exception
- https://en.cppreference.com/w/cpp/preprocessor/replace (`__cplusplus | denotes the version of C++ standard that is being used, expands to value 199711L(until C++11), 201103L(C++11), 201402L(C++14), 201703L(C++17), or 202002L(C++20)` 

