### PR TITLE
fix current_zone detection on buildroot with glibc

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -351,11 +351,14 @@ discover_tz_dir()
     using namespace std;
 #  ifndef __APPLE__
     CONSTDATA auto tz_dir_default = "/usr/share/zoneinfo";
-    CONSTDATA auto tz_dir_buildroot = "/usr/share/zoneinfo/uclibc";
+    CONSTDATA auto tz_dir_buildroot_uclibc = "/usr/share/zoneinfo/uclibc";
+    CONSTDATA auto tz_dir_buildroot_glibc = "/usr/share/zoneinfo/posix";
 
-    // Check special path which is valid for buildroot with uclibc builds
-    if(stat(tz_dir_buildroot, &sb) == 0 && S_ISDIR(sb.st_mode))
-        return tz_dir_buildroot;
+    // Check special paths which are valid for buildroot with uclibc/glibc builds
+    if(stat(tz_dir_buildroot_uclibc, &sb) == 0 && S_ISDIR(sb.st_mode))
+        return tz_dir_buildroot_uclibc;
+    else if(stat(tz_dir_buildroot_glibc, &sb) == 0 && S_ISDIR(sb.st_mode))
+        return tz_dir_buildroot_glibc;
     else if(stat(tz_dir_default, &sb) == 0 && S_ISDIR(sb.st_mode))
         return tz_dir_default;
     else

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3707,7 +3707,7 @@ extract_tz_name(char const* rp)
             "current_zone() failed to find \"zoneinfo\" in " + string(result));
     pos = result.find(get_tz_dir());
     if (pos != result.npos)
-        result.erase(0, get_tz_dir().size() + 1 + pos);
+        result.remove_prefix(get_tz_dir().size() + 1 + pos);
     return result;
 }
 


### PR DESCRIPTION
I supplied the original patch for buildroot with uclibc but now wanted to use glibc, which seems to behave different.
Hopefully this patch should make everyone happy. Let's see what CI will say in minute.

*All the details on why this change was made*

What is wrong: The current_zone is detected as __posix/Europe/Berlin__

When using glibc the proper link is found in /etc/localtime (not on /etc/TZ). This is correct.

I looks like this:
```
# ls -l /etc/localtime
lrwxrwxrwx    1 root     root            39 Aug 27 11:56 /etc/localtime -> ../usr/share/zoneinfo/Europe/Berlin
```

The realpath differs, as the real tzdb resides in the /usr/share/zoneinfo/posix folder:
```
# realpath /etc/localtime
/usr/share/zoneinfo/posix/Europe/Berlin
```

Looking into /usr/share/zoneinfo we get this:
```
# ls -l /usr/share/zoneinfo/
total 48
lrwxrwxrwx    1 root     root            12 Aug 27 08:08 Africa -> posix/Africa
... a lot of more links into posix/* ...
lrwxrwxrwx    1 root     root            10 Aug 27 08:08 Zulu -> posix/Zulu
-rw-r--r--    1 root     root          4463 Feb 20  2019 iso3166.tab
drwxr-xr-x   18 root     root             0 Aug 27 08:08 posix
drwxr-xr-x   18 root     root             0 Aug 27 08:08 right
-rw-r--r--    1 root     root         19397 Mar 10 01:39 zone.tab
-rw-r--r--    1 root     root         17911 Mar 10 01:39 zone1970.tab
```

What is happening:
current_zone() will use the standard glibc detection, which will determine /usr/share/zoneinfo/posix/Europe/Berlin as the realpath. extract_tz_name will then cut after zoneinfo which will leave __posix/Europe/Berlin as the timezone__, which is not correct.

This PR suggests to rework extract_tz_name to reuse the mechanism which is implemented in the TZ detection for uclibc plus add the validation that "zoneinfo" is included in the mentioned path. This new extract_tz_name function could then also be used for the uclibc variant. Then also update the get_tz_dir detection to recognize the buildroot glibc variant.