### PR TITLE
Put back handling DISABLE_STRING_VIEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
   target_compile_definitions( date INTERFACE ONLY_C_LOCALE=0 )
 endif()
 if ( DISABLE_STRING_VIEW )
-  target_compile_definitions( date INTERFACE HAS_STRING_VIEW=0 )
+  target_compile_definitions( date INTERFACE HAS_STRING_VIEW=0 -DHAS_DEDUCTION_GUIDES=0 )
 endif()
 
 #[===================================================================[
@@ -155,9 +155,6 @@ if( BUILD_TZ_LIB )
         find_package( CURL REQUIRED )
         target_include_directories( date-tz SYSTEM PRIVATE ${CURL_INCLUDE_DIRS} )
         target_link_libraries( date-tz PRIVATE ${CURL_LIBRARIES} )
-    endif( )
-    if( DISABLE_STRING_VIEW )
-      target_compile_definitions( date-tz PRIVATE -DHAS_STRING_VIEW=0 -DHAS_DEDUCTION_GUIDES=0 )
     endif( )
 endif( )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,9 @@ if( BUILD_TZ_LIB )
         target_include_directories( date-tz SYSTEM PRIVATE ${CURL_INCLUDE_DIRS} )
         target_link_libraries( date-tz PRIVATE ${CURL_LIBRARIES} )
     endif( )
+    if( DISABLE_STRING_VIEW )
+      target_compile_definitions( date-tz PRIVATE -DHAS_STRING_VIEW=0 -DHAS_DEDUCTION_GUIDES=0 )
+    endif( )
 endif( )
 
 #[===================================================================[


### PR DESCRIPTION
Commit 48f1455 dropped handling DISABLE_STRING_VIEW. This PR put it back as well as setting HAS_DEDUCTION_GUIDES which requires string view as well.