### PR TITLE
Skip "version" file and USE_OS_TZDB to return "unknown" if no version…

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2651,7 +2651,7 @@ get_version()
         in >> version;
         return version;
     }
-    return version;
+    return "unknown";
 }
 
 static
@@ -2760,6 +2760,7 @@ init_tzdb()
                 strcmp(d->d_name, "iso3166.tab")  == 0      ||
                 strcmp(d->d_name, "right")        == 0      ||
                 strcmp(d->d_name, "+VERSION")     == 0      ||
+                strcmp(d->d_name, "version")      == 0      ||
                 strcmp(d->d_name, "zone.tab")     == 0      ||
                 strcmp(d->d_name, "zone1970.tab") == 0      ||
                 strcmp(d->d_name, "tzdata.zi")    == 0      ||


### PR DESCRIPTION
… found

In commit commit 0b72599bd43f72d8935e507e25e4f0063f9bb34e there
was a change to read "version" in addition to "+VERSION", so that
file shold also be ignored when scanning/reading zonefiles.

Also before the above mentioed commit get_version() would return
"unknown" if not on __APPLE__ and the version file was not found.
Put back that behaviour, for all USE_OS_TZDB users.

This last change changes the behaviour for __APPLE__ from throwing
an exception to returning "unknown".