### PR TITLE
Resolve #618 (Specify TZDB location via CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ option( ENABLE_DATE_TESTING "Enable unit tests" OFF )
 option( DISABLE_STRING_VIEW "Disable string view" OFF )
 option( COMPILE_WITH_C_LOCALE "define ONLY_C_LOCALE=1" OFF )
 option( BUILD_TZ_LIB "build/install of TZ library" OFF )
+option( USE_CUSTOM_TZDB_INSTALL_PATH "Use a custom path for finding the tzdata folder" OFF )
+# The location of the database is CUSTOM_TZDB_INSTALL_PATH/tzdata (CUSTOM_TZDB_INSTALL_PATH\tzdata on Windows)
+set(CUSTOM_TZDB_INSTALL_PATH ".")
 
 if( ENABLE_DATE_TESTING AND NOT BUILD_TZ_LIB )
     message(WARNING "Testing requested, bug BUILD_TZ_LIB not ON - forcing the latter")
@@ -55,6 +58,10 @@ print_option( USE_TZ_DB_IN_DOT )
 print_option( BUILD_SHARED_LIBS  )
 print_option( ENABLE_DATE_TESTING )
 print_option( DISABLE_STRING_VIEW )
+print_option( USE_CUSTOM_TZDB_INSTALL_PATH )
+if(USE_CUSTOM_TZDB_INSTALL_PATH)
+    message("# date: CUSTOM_TZDB_INSTALL_PATH ${CUSTOM_TZDB_INSTALL_PATH}")
+endif()
 
 #[===================================================================[
    date (header only) library
@@ -95,6 +102,9 @@ else()
 endif()
 if ( DISABLE_STRING_VIEW )
   target_compile_definitions( date INTERFACE HAS_STRING_VIEW=0 -DHAS_DEDUCTION_GUIDES=0 )
+endif()
+if ( USE_CUSTOM_TZDB_INSTALL_PATH )
+  target_compile_definitions( date INTERFACE TZDB_INSTALL_PATH=${CUSTOM_TZDB_INSTALL_PATH} )
 endif()
 
 #[===================================================================[

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -123,7 +123,7 @@
 #    include <winapifamily.h>
 #    if WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP
 #      define WINRT
-#      define INSTALL .
+#      define TZDB_INSTALL_PATH .
 #    endif
 #  endif
 
@@ -141,7 +141,7 @@
 #  endif  // HAS_REMOTE_API
 #else   // !_WIN32
 #  include <unistd.h>
-#  if !USE_OS_TZDB && !defined(INSTALL)
+#  if !USE_OS_TZDB && !defined(TZDB_INSTALL_PATH)
 #    include <wordexp.h>
 #  endif
 #  include <limits.h>
@@ -222,7 +222,7 @@ get_known_folder(const GUID& folderid)
     return folder;
 }
 
-#      ifndef INSTALL
+#      ifndef TZDB_INSTALL_PATH
 
 // Usually something like "c:\Users\username\Downloads".
 static
@@ -232,12 +232,12 @@ get_download_folder()
     return get_known_folder(FOLDERID_Downloads);
 }
 
-#      endif  // !INSTALL
+#      endif  // !TZDB_INSTALL_PATH
 
 #    endif // WINRT
 #  else // !_WIN32
 
-#    if !defined(INSTALL)
+#    if !defined(TZDB_INSTALL_PATH)
 
 static
 std::string
@@ -263,7 +263,7 @@ get_download_folder()
     return expand_path("~/Downloads");
 }
 
-#    endif // !defined(INSTALL)
+#    endif // !defined(TZDB_INSTALL_PATH)
 
 #  endif  // !_WIN32
 
@@ -284,20 +284,20 @@ std::string&
 access_install()
 {
     static std::string install
-#ifndef INSTALL
+#ifndef TZDB_INSTALL_PATH
 
     = get_download_folder() + folder_delimiter + "tzdata";
 
-#else   // !INSTALL
+#else   // !TZDB_INSTALL_PATH
 
 #  define STRINGIZEIMP(x) #x
 #  define STRINGIZE(x) STRINGIZEIMP(x)
 
-    = STRINGIZE(INSTALL) + std::string(1, folder_delimiter) + "tzdata";
+    = STRINGIZE(TZDB_INSTALL_PATH) + std::string(1, folder_delimiter) + "tzdata";
 
     #undef STRINGIZEIMP
     #undef STRINGIZE
-#endif  // !INSTALL
+#endif  // !TZDB_INSTALL_PATH
 
     return install;
 }


### PR DESCRIPTION
I went ahead and renamed `INSTALL` to `TZDB_INSTALL_PATH` to reduce possibility of name conflicts.

NOTE: A common issue may be that you have multiple executables with different relative paths. I resolve that by inserting a copy of the `tzdata` folder at the same relative path from the each executable.

Related: #618 