### PR TITLE
ADD settable zoneinfo directory functions

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -1299,6 +1299,14 @@ DATE_API tzdb_list& get_tzdb_list();
 DATE_API const tzdb& reload_tzdb();
 DATE_API void        set_install(const std::string& install);
 
+#else // USE_OS_TZDB
+
+static
+std::string& get_user_tz_dir();
+
+void
+set_tz_dir(const std::string& tz_dir);
+
 #endif  // !USE_OS_TZDB
 
 #if HAS_REMOTE_API

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -326,6 +326,20 @@ get_download_gz_file(const std::string& version)
 }
 #endif  // HAS_REMOTE_API
 
+#else // USE_OS_TZDB
+
+static
+std::string& get_user_tz_dir()
+{
+    static std::string tz_dir = "/usr/share/zoneinfo";
+    return tz_dir;
+}
+
+void
+set_tz_dir(const std::string& tz_dir)
+{
+    get_user_tz_dir() = tz_dir;
+}
 #endif  // !USE_OS_TZDB
 
 // These can be used to reduce the range of the database to save memory
@@ -350,11 +364,14 @@ discover_tz_dir()
     struct stat sb;
     using namespace std;
 #  ifndef __APPLE__
+    auto tz_dir_user = get_user_tz_dir().c_str();
     CONSTDATA auto tz_dir_default = "/usr/share/zoneinfo";
     CONSTDATA auto tz_dir_buildroot = "/usr/share/zoneinfo/uclibc";
 
     // Check special path which is valid for buildroot with uclibc builds
-    if(stat(tz_dir_buildroot, &sb) == 0 && S_ISDIR(sb.st_mode))
+    if (stat(tz_dir_user, &sb) == 0 && S_ISDIR(sb.st_mode))
+        return tz_dir_user;
+    else if(stat(tz_dir_buildroot, &sb) == 0 && S_ISDIR(sb.st_mode))
         return tz_dir_buildroot;
     else if(stat(tz_dir_default, &sb) == 0 && S_ISDIR(sb.st_mode))
         return tz_dir_default;


### PR DESCRIPTION
In response to this issue  https://github.com/HowardHinnant/date/issues/626 I've made only minor changes to the base library to allow for users to call a `set_tz_dir` function for setting a custom zoneinfo directory. 

The use case for these changes are when you don't want to use the standard zoneinfo directory at `/usr/share/zoneinfo`. Users can call the `set_tz_dir` function before initializing the database. If the path the user has specified does not exist or is not a directory, it falls back to the standard paths the library looks for.