### PR TITLE
Feature - Setting the binary tzdb directory path at runtime

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -43,8 +43,16 @@
 // required. On Windows, the names are never "Standard" so mapping is always required.
 // Technically any OS may use the mapping process but currently only Windows does use it.
 
+#ifndef USE_OS_TZDB
+#  define USE_OS_TZDB 0
+#endif
+
 #ifndef USE_BINARY_TZDB
-#  define USE_BINARY_TZDB 0
+#  define USE_BINARY_TZDB USE_OS_TZDB
+#endif
+
+#if (!USE_BINARY_TZDB) && (USE_OS_TZDB)
+#  define error "If USE_OS_TZDB is used, then USE_BINARY_TZDB must also be used."
 #endif
 
 #ifndef HAS_REMOTE_API
@@ -82,9 +90,9 @@ static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,
 #  define USE_SHELL_API 1
 #endif
 
-#if USE_BINARY_TZDB
+#if USE_OS_TZDB || USE_BINARY_TZDB
 #  ifdef _WIN32
-#    error "USE_BINARY_TZDB can not be used on Windows"
+#    error "USE_OS_TZDB and USE_BINARY_TZDB can not be used on Windows"
 #  endif
 #endif
 
@@ -1294,12 +1302,14 @@ tzdb_list::cend() const NOEXCEPT
 
 DATE_API tzdb_list& get_tzdb_list();
 
-#if !USE_BINARY_TZDB
-
+#if USE_BINARY_TZDB
+#  if !USE_OS_TZDB
+DATE_API void set_tz_dir(const std::string& tz_dir);
+#  endif // !USE_OS_TZDB
+#else // !USE_BINARY_TZDB
 DATE_API const tzdb& reload_tzdb();
 DATE_API void        set_install(const std::string& install);
-
-#endif  // !USE_BINARY_TZDB
+#endif // USE_BINARY_TZDB
 
 #if HAS_REMOTE_API
 

--- a/include/date/tz_private.h
+++ b/include/date/tz_private.h
@@ -40,7 +40,7 @@ namespace date
 namespace detail
 {
 
-#if !USE_OS_TZDB
+#if !USE_BINARY_TZDB
 
 enum class tz {utc, local, standard};
 
@@ -256,7 +256,7 @@ struct zonelet
     zonelet& operator=(const zonelet&) = delete;
 };
 
-#else  // USE_OS_TZDB
+#else  // USE_BINARY_TZDB
 
 struct ttinfo
 {
@@ -303,7 +303,7 @@ struct transition
     }
 };
 
-#endif  // USE_OS_TZDB
+#endif  // USE_BINARY_TZDB
 
 }  // namespace detail
 

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3833,6 +3833,7 @@ tzdb::current_zone() const
             return locate_zone(extract_tz_name(rp));
         }
     }
+#if USE_BINARY_TZDB
     // On embedded systems e.g. buildroot with uclibc the timezone is linked
     // into /etc/TZ which is a symlink to path like this:
     // "/usr/share/zoneinfo/uclibc/America/Los_Angeles"
@@ -3861,6 +3862,7 @@ tzdb::current_zone() const
             return locate_zone(result);
         }
     }
+#endif // USE_BINARY_TZDB
     {
     // On some versions of some linux distro's (e.g. Ubuntu),
     // the current timezone might be in the first line of

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -92,7 +92,7 @@
 #  define TARGET_OS_SIMULATOR 0
 #endif
 
-#if USE_OS_TZDB
+#if USE_BINARY_TZDB
 #  include <dirent.h>
 #endif
 #include <algorithm>
@@ -105,7 +105,7 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
-#if USE_OS_TZDB
+#if USE_BINARY_TZDB
 #  include <queue>
 #endif
 #include <sstream>
@@ -141,7 +141,7 @@
 #  endif  // HAS_REMOTE_API
 #else   // !_WIN32
 #  include <unistd.h>
-#  if !USE_OS_TZDB && !defined(INSTALL)
+#  if !USE_BINARY_TZDB && !defined(INSTALL)
 #    include <wordexp.h>
 #  endif
 #  include <limits.h>
@@ -180,7 +180,7 @@ static CONSTDATA char folder_delimiter = '/';
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif  // defined(__GNUC__) && __GNUC__ < 5
 
-#if !USE_OS_TZDB
+#if !USE_BINARY_TZDB
 
 #  ifdef _WIN32
 #    ifndef WINRT
@@ -267,7 +267,7 @@ get_download_folder()
 
 #  endif  // !_WIN32
 
-#endif  // !USE_OS_TZDB
+#endif  // !USE_BINARY_TZDB
 
 namespace date
 {
@@ -277,7 +277,7 @@ namespace date
 
 using namespace detail;
 
-#if !USE_OS_TZDB
+#if !USE_BINARY_TZDB
 
 static
 std::string&
@@ -326,7 +326,7 @@ get_download_gz_file(const std::string& version)
 }
 #endif  // HAS_REMOTE_API
 
-#endif  // !USE_OS_TZDB
+#endif  // !USE_BINARY_TZDB
 
 // These can be used to reduce the range of the database to save memory
 CONSTDATA auto min_year = date::year::min();
@@ -335,11 +335,11 @@ CONSTDATA auto max_year = date::year::max();
 CONSTDATA auto min_day = date::January/1;
 CONSTDATA auto max_day = date::December/31;
 
-#if USE_OS_TZDB
+#if USE_BINARY_TZDB
 
 CONSTCD14 const sys_seconds min_seconds = sys_days(min_year/min_day);
 
-#endif  // USE_OS_TZDB
+#endif  // USE_BINARY_TZDB
 
 #ifndef _WIN32
 
@@ -491,7 +491,7 @@ parse_month(std::istream& in)
     return static_cast<unsigned>(++m);
 }
 
-#if !USE_OS_TZDB
+#if !USE_BINARY_TZDB
 
 #ifdef _WIN32
 
@@ -1718,11 +1718,11 @@ detail::zonelet::zonelet(const zonelet& i)
 #endif
 }
 
-#endif  // !USE_OS_TZDB
+#endif  // !USE_BINARY_TZDB
 
 // time_zone
 
-#if USE_OS_TZDB
+#if USE_BINARY_TZDB
 
 time_zone::time_zone(const std::string& s, detail::undocumented)
     : name_(s)
@@ -2226,7 +2226,7 @@ leap_second::leap_second(const sys_seconds& s, detail::undocumented)
 {
 }
 
-#else  // !USE_OS_TZDB
+#else  // !USE_BINARY_TZDB
 
 time_zone::time_zone(const std::string& s, detail::undocumented)
     : adjusted_(new std::once_flag{})
@@ -2620,7 +2620,7 @@ operator<<(std::ostream& os, const time_zone& z)
     return os;
 }
 
-#endif  // !USE_OS_TZDB
+#endif  // !USE_BINARY_TZDB
 
 std::ostream&
 operator<<(std::ostream& os, const leap_second& x)
@@ -2629,7 +2629,7 @@ operator<<(std::ostream& os, const leap_second& x)
     return os << x.date_ << "  +";
 }
 
-#if USE_OS_TZDB
+#if USE_BINARY_TZDB
 
 static
 std::string
@@ -2793,7 +2793,7 @@ init_tzdb()
     return db;
 }
 
-#else  // !USE_OS_TZDB
+#else  // !USE_BINARY_TZDB
 
 // time_zone_link
 
@@ -3569,7 +3569,7 @@ reload_tzdb()
     return get_tzdb_list().front();
 }
 
-#endif  // !USE_OS_TZDB
+#endif  // !USE_BINARY_TZDB
 
 const tzdb&
 get_tzdb()
@@ -3595,7 +3595,7 @@ tzdb::locate_zone(const std::string& tz_name) const
         });
     if (zi == zones.end() || zi->name() != tz_name)
     {
-#if !USE_OS_TZDB
+#if !USE_BINARY_TZDB
         auto li = std::lower_bound(links.begin(), links.end(), tz_name,
 #if HAS_STRING_VIEW
         [](const time_zone_link& z, const std::string_view& nm)
@@ -3615,7 +3615,7 @@ tzdb::locate_zone(const std::string& tz_name) const
             if (zi != zones.end() && zi->name() == li->target())
                 return &*zi;
         }
-#endif  // !USE_OS_TZDB
+#endif  // !USE_BINARY_TZDB
         throw std::runtime_error(std::string(tz_name) + " not found in timezone database");
     }
     return &*zi;
@@ -3631,7 +3631,7 @@ locate_zone(const std::string& tz_name)
     return get_tzdb().locate_zone(tz_name);
 }
 
-#if USE_OS_TZDB
+#if USE_BINARY_TZDB
 
 std::ostream&
 operator<<(std::ostream& os, const tzdb& db)
@@ -3645,7 +3645,7 @@ operator<<(std::ostream& os, const tzdb& db)
     return os;
 }
 
-#else  // !USE_OS_TZDB
+#else  // !USE_BINARY_TZDB
 
 std::ostream&
 operator<<(std::ostream& os, const tzdb& db)
@@ -3704,7 +3704,7 @@ operator<<(std::ostream& os, const tzdb& db)
     return os;
 }
 
-#endif  // !USE_OS_TZDB
+#endif  // !USE_BINARY_TZDB
 
 // -----------------------
 


### PR DESCRIPTION
Closes #626 
A step towards #564 

This PR allows for setting the time zone database directory path at runtime. It does so through a new helper, `set_tz_dir()`, which must be called before the tzdb is initialized if the user has declared that they are going to manually set the path at runtime.

Because the binary tzdb parser does not yet work on Windows, this PR does not enable the runtime setting of the path on Windows. That said, the eventual goal to resolve #564 is to fix the binary tzdb parser on Windows, and then to enable runtime setting of the directory path there. That should bring really nice performance improvements to Windows.

There is a new option, `USE_BINARY_TZDB`. `USE_OS_TZDB` can be thought of as a subset of this. If `USE_BINARY_TZDB` is turned on, but `USE_OS_TZDB` is not, then the client is required to call `set_tz_dir()` before initializing the tzdb, otherwise a runtime error is thrown. If `USE_OS_TZDB` _is_ on, then the automatic detection of the OS tzdb is done instead, and `set_tz_dir()` is not exposed.

If `USE_BINARY_TZDB` is not defined, then it is set to `USE_OS_TZDB` to be compatible with all previous versions of date.

---

There are two additional changes that I felt had to be made to merge this PR.

Previously, `discover_tz_dir()` and `get_tz_dir()` were always defined if on a non-Windows platform, even if `USE_OS_TZDB` was not defined. I considered this a bug. `discover_tz_dir()` is now only defined when `USE_OS_TZDB` is on (otherwise you don't need to discover it), and `get_tz_dir()` is defined if either `USE_OS_TZDB` or `USE_BINARY_TZDB` is defined. It is required for `get_tz_dir()` to be implemented this way to eventually add support for `USE_BINARY_TZDB` on Windows (i.e. we can't just turn off support for it when on Windows, as is currently done).

I have changed the non-Windows implementation of `current_zone()` to only call `get_tz_dir()` when `USE_OS_TZDB` is on. This is a direct result of the previously mentioned change. It seems like `current_zone()` only calls `get_tz_dir()` in embedded systems and is related to a symlink to an OS tzdb path, so it really feels like `USE_OS_TZDB` should have to be active for this to work properly anyways. It would not be sufficient for `USE_BINARY_TZDB` to be on, but `USE_OS_TZDB` to be off, because this could be a custom location that the symlink probably won't point to.

---

To make sure this is working, I turned it on over in the project I am working on. It seems to work nicely for me on my Mac https://github.com/DavisVaughan/clock/pull/49

I'm not very familiar with C++ testing, so feel free to make changes against this PR as you see fit if you'd like to accept it.