### PR TITLE
Cast to `unsigned char` before calling `toupper()`

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -4779,7 +4779,7 @@ scan_keyword(std::basic_istream<CharT, Traits>& is, FwdIter kb, FwdIter ke)
             is.setstate(std::ios::eofbit);
             break;
         }
-        auto c = static_cast<char>(toupper(ic));
+        auto c = static_cast<char>(toupper(static_cast<unsigned char>(ic)));
         bool consume = false;
         // For each keyword which might match, see if the indx character is c
         // If a match if found, consume c
@@ -4792,7 +4792,7 @@ scan_keyword(std::basic_istream<CharT, Traits>& is, FwdIter kb, FwdIter ke)
         {
             if (*st == might_match)
             {
-                if (c == static_cast<char>(toupper((*ky)[indx])))
+                if (c == static_cast<char>(toupper(static_cast<unsigned char>((*ky)[indx]))))
                 {
                     consume = true;
                     if (ky->size() == indx+1)


### PR DESCRIPTION
Closes #647 

As discussed in #647, the docs for `toupper()` recommend casting to `unsigned char` before calling it. Any input not representable as an `unsigned char` results in undefined behavior.