### PR TITLE
std::uncaught_exception() is deprecated in C++17, causing build failures

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -136,7 +136,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus > 201703 || (defined(_MSVC_LANG) && _MSVC_LANG > 201703L)
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0


### PR DESCRIPTION
std::uncaught_exceptions() is available since C++17, and std::uncaught_exception() is already deprecated in C++17, leading to error in "treat warnings as errors" mode in MSVC 2019 in C++17 mode.