### PR TITLE
Add global cleanup to curl object destructor

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2863,6 +2863,7 @@ struct curl_deleter
     void operator()(CURL* p) const
     {
         ::curl_easy_cleanup(p);
+        ::curl_global_cleanup();
     }
 };
 


### PR DESCRIPTION
Curl resources are leaked without this