### PR TITLE
Add flags in README to compile using cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can optionally build using [CMake](https://cmake.org/). Here is a guide of h
 ```bash
 mkdir build
 cd build
-cmake ../
+cmake -DENABLE_DATE_TESTING=ON -DBUILD_TZ_LIB=ON ../
 cmake --build . --target testit # Consider '-- -j4' for multithreading
 ```
 ## Projects using this library


### PR DESCRIPTION
- The instructions to build the library using CMAKE are wrong. It is necessary to add these flags or it will not recognize the `testit` target in the build time.