### PR TITLE
static_cast to silent warning implict conversion

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -6405,7 +6405,7 @@ read_long_double(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned
         is.setstate(std::ios::failbit);
         return 0;
     }
-    return i + f/std::pow(10.L, fcount);
+    return static_cast<long double>(i) + static_cast<long double>(f)/std::pow(10.L, fcount);
 }
 
 struct rs


### PR DESCRIPTION
That happen because `sizeof(long long unsigned int) == sizeof(long double)` in 32-bit architectures.