### PR TITLE
test: use -pthread when $CXX is g++

### DIFF
--- a/test/testit
+++ b/test/testit
@@ -48,6 +48,12 @@ if [ -z "$CXX_LANG" ]
 then
     CXX_LANG=c++17
 fi
+
+if expr "$CXX" : ".*g++" >/dev/null
+then
+	OPTIONS="$OPTIONS -pthread"
+fi
+
 OPTIONS="-std=${CXX_LANG} $OPTIONS -I$ROOT -Wall $ROOT/src/tz.cpp -lcurl"
 
 echo $ROOT


### PR DESCRIPTION
Fixes https://github.com/HowardHinnant/date/issues/713