### PR TITLE
Sync implementation and header signatures

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -845,7 +845,7 @@ private:
     load_data(std::istream& inf, std::int32_t tzh_leapcnt, std::int32_t tzh_timecnt,
                                  std::int32_t tzh_typecnt, std::int32_t tzh_charcnt);
 #else  // !USE_OS_TZDB
-    DATE_API sys_info   get_info_impl(sys_seconds tp, int timezone) const;
+    DATE_API sys_info   get_info_impl(sys_seconds tp, int tz_int) const;
     DATE_API void adjust_infos(const std::vector<detail::Rule>& rules);
     DATE_API void parse_info(std::istream& in);
 #endif  // !USE_OS_TZDB

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -415,9 +415,9 @@ access_install()
 }
 
 void
-set_install(const std::string& s)
+set_install(const std::string& install)
 {
-    access_install() = s;
+    access_install() = install;
 }
 
 static


### PR DESCRIPTION
A user pointed out in https://github.com/r-lib/tzdb/pull/19 that two signatures are out of sync (and apparently _only_ these two, according to their build tools). This PR just syncs them back up.

## set_install

I chose to go with `install` here, as that seemed more informative.

https://github.com/HowardHinnant/date/blob/3776e0f18562b8813a8733aed3677e01e960a5a2/include/date/tz.h#L1300

https://github.com/HowardHinnant/date/blob/3776e0f18562b8813a8733aed3677e01e960a5a2/src/tz.cpp#L418

## get_info_impl

I chose to go with `tz_int` here, because in the implementation you perform a static cast of this `int tz_int` object to a `tz timezone` and that "real" `tz` object feels like it should have the better name.

https://github.com/HowardHinnant/date/blob/3776e0f18562b8813a8733aed3677e01e960a5a2/include/date/tz.h#L848

https://github.com/HowardHinnant/date/blob/3776e0f18562b8813a8733aed3677e01e960a5a2/src/tz.cpp#L2611-L2615