### PR TITLE
Fix hh_mm_ss name conflict with C++20

### DIFF
--- a/include/date/ptz.h
+++ b/include/date/ptz.h
@@ -599,7 +599,7 @@ time_zone::name() const
     auto print_offset = [](seconds off)
         {
             std::string nm;
-            hh_mm_ss<seconds> offset{-off};
+            date::hh_mm_ss<seconds> offset{-off};
             if (offset.is_negative())
                 nm += '-';
             nm += std::to_string(offset.hours().count());


### PR DESCRIPTION
There is a name conflict between `std::chrono::hh_mm_ss` and `date::hh_mm_ss` when building with C++20.