### PR TITLE
build: use standard `CMAKE_INSTALL_INCLUDEDIR` for header install folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,10 @@ add_library( date INTERFACE )
 add_library( date::date ALIAS date )
 target_include_directories( date INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include> )
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 # adding header sources just helps IDEs
 target_sources( date INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:include>/date/date.h
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/date/date.h
     # the rest of these are not currently part of the public interface of the library:
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/date/solar_hijri.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/date/islamic.h>
@@ -104,14 +104,14 @@ if( BUILD_TZ_LIB )
     add_library( date-tz )
     target_sources( date-tz
       PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:include>/date/tz.h
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/date/tz.h
       PRIVATE
         include/date/tz_private.h
         src/tz.cpp )
     if ( IOS )
       target_sources( date-tz
         PUBLIC
-          $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:include>/date/ios.h
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/date/ios.h
         PRIVATE
           src/ios.mm )
     endif()
@@ -119,7 +119,7 @@ if( BUILD_TZ_LIB )
     target_link_libraries( date-tz PUBLIC date )
     target_include_directories( date-tz PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include> )
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
     if ( USE_SYSTEM_TZ_DB OR MANUAL_TZ_DB )
       target_compile_definitions( date-tz PRIVATE AUTO_DOWNLOAD=0 HAS_REMOTE_API=0 )


### PR DESCRIPTION
This gives user control over which folder header should be installed to instead of using hardcoded value `include/`. Variable `CMAKE_INSTALL_INCLUDEDIR` is provided after a call to `include(GNUInstallDirs)`
More info can be found about usage in docs: https://cmake.org/cmake/help/latest/command/install.html

This PR basically replace all `$<INSTALL_INTERFACE:include>` with `$<INSTALL_INTERFACE:include>`.

---

It was already correctly used here: 
https://github.com/HowardHinnant/date/blob/22ceabf205d8d678710a43154da5a06b701c5830/CMakeLists.txt#L173
here: https://github.com/HowardHinnant/date/blob/22ceabf205d8d678710a43154da5a06b701c5830/CMakeLists.txt#L178
and here: https://github.com/HowardHinnant/date/blob/22ceabf205d8d678710a43154da5a06b701c5830/CMakeLists.txt#L184

---

This fix a bug if user provide `-DCMAKE_INSTALL_INCLUDEDIR=customfolder`, right now generated `CMake/dateTargets.cmake` output a file with:
```cmake
set_target_properties(date::date PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "ONLY_C_LOCALE=0"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_SOURCES "${_IMPORT_PREFIX}/include/date/date.h"
)
```

With this PR, generated file will be:
```cmake
set_target_properties(date::date PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "ONLY_C_LOCALE=0"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/customfolder"
  INTERFACE_SOURCES "${_IMPORT_PREFIX}/customfolder/date/date.h"
)
```