### PR TITLE
build: don't write to global variable `CMAKE_CXX_STANDARD`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 #]===================================================================]
 
-cmake_minimum_required( VERSION 3.7 )
+cmake_minimum_required( VERSION 3.8 )
 
 project( date VERSION 3.0.1 )
 set(ABI_VERSION 3) # used as SOVERSION, increment when ABI changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,6 @@ include( GNUInstallDirs )
 
 get_directory_property( has_parent PARENT_DIRECTORY )
 
-# Override by setting on CMake command line.
-set( CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are requested." )
-
 option( USE_SYSTEM_TZ_DB "Use the operating system's timezone database" OFF )
 option( MANUAL_TZ_DB "User will set TZ DB manually by invoking set_install in their code" OFF )
 option( USE_TZ_DB_IN_DOT "Save the timezone database in the current folder" OFF )
@@ -73,6 +70,7 @@ target_sources( date INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/date/iso_week.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/date/julian.h>
 )
+target_compile_features( date INTERFACE cxx_std_11 )
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
     # public headers will get installed:
     set_target_properties( date PROPERTIES PUBLIC_HEADER include/date/date.h )


### PR DESCRIPTION
Instead use modern `target_compile_features` with `cxx_std_11` (since this project is compatible with C++11 and later). More information: https://cmake.org/cmake/help/latest/command/target_compile_features.html

If user wants to access c++14/17/20 features, it is up to him to define cxx_std_<version> on his target. Or he can still use the old school CMAKE_CXX_STANDARD global variable.

This commit might break project relying on `date` writing to a global variable. If user links his target to date, his target will be promoted at least to c++11 if not specified otherwise.