### PR TITLE
build: disable logs when `date` is not the main CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@
 
 cmake_minimum_required( VERSION 3.7 )
 
+set(DATE_MAIN_PROJECT OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(DATE_MAIN_PROJECT ON)
+endif()
+
 project( date VERSION 3.0.1 )
 set(ABI_VERSION 3) # used as SOVERSION, increment when ABI changes
 
@@ -42,7 +47,7 @@ if( ENABLE_DATE_TESTING AND NOT BUILD_TZ_LIB )
 endif( )
 
 function( print_option OPT )
-    if ( NOT DEFINED PRINT_OPTION_CURR_${OPT} OR ( NOT PRINT_OPTION_CURR_${OPT} STREQUAL ${OPT} ) )
+    if ( DATE_MAIN_PROJECT AND ( NOT DEFINED PRINT_OPTION_CURR_${OPT} OR ( NOT PRINT_OPTION_CURR_${OPT} STREQUAL ${OPT} ) ) )
         set( PRINT_OPTION_CURR_${OPT} ${${OPT}} CACHE BOOL "" )
         mark_as_advanced(PRINT_OPTION_CURR_${OPT})
         message( "# date: ${OPT} ${${OPT}}" )


### PR DESCRIPTION
When including `date` with `add_subdirectory`, users logs are polluted with config from `date`. Using `PROJECT_IS_TOP_LEVEL` would be even more appropriate (https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html#variable:PROJECT_IS_TOP_LEVEL) but it require CMake v3.21 as minimal version.