### PR TITLE
build(cmake): always mark HAS_STRING_VIEW as part of the interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ else()
 endif()
 if ( DISABLE_STRING_VIEW )
   target_compile_definitions( date INTERFACE HAS_STRING_VIEW=0 -DHAS_DEDUCTION_GUIDES=0 )
+else()
+  target_compile_definitions( date INTERFACE HAS_STRING_VIEW=1 )
 endif()
 
 #[===================================================================[


### PR DESCRIPTION
If the library gets compiled with `HAS_STRING_VIEW=1`, consumers always need to link to the functions using `std::string_view`, as they are the only ones compiled into the shared library.

If the library gets compiled with e.g. C++17 and the user uses an older standard version they'll still get an error, but an helpful compile-time one suggesting to enable C++17 mode, instead of a cryptic linking error.

You can find a longer explanation here: <https://github.com/HowardHinnant/date/pull/754#issuecomment-1361248007>