### PR TITLE
docs: support dark color-scheme

### DIFF
--- a/chrono_io.html
+++ b/chrono_io.html
@@ -4,20 +4,17 @@
 <head>
 	<title>chrono_io</title>
 
+	<meta name="color-scheme" content="light dark" />
 	<style>
-	p {text-align:justify}
-	li {text-align:justify}
-	blockquote.note
-	{
-		background-color:#E0E0E0;
-		padding-left: 15px;
-		padding-right: 15px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-	}
+	li, p {text-align:justify}
 	ins {color:#00A000}
 	del {color:#A00000}
 	code {white-space:pre;}
+	@media (prefers-color-scheme: dark)
+	{
+		ins {color:#88FF88}
+		del {color:#FF5555}
+	}
 	</style>
 </head>
 <body>

--- a/d0355r7.html
+++ b/d0355r7.html
@@ -3,19 +3,11 @@
 <html>
 <head>
 	<meta charset="utf-8">
+	<meta name="color-scheme" content="light dark">
 	<title>Extending &lt;chrono&gt; to Calendars and Time Zones</title>
-    <style type="text/css">
-	p {text-align:justify}
-	li {text-align:justify}
-	blockquote.note
-	{
-		background-color:#E0E0E0;
-		padding-left: 15px;
-		padding-right: 15px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-	}
-	p.note
+	<style type="text/css">
+	li, p {text-align:justify}
+	blockquote.note, p.note
 	{
 		background-color:#E0E0E0;
 		padding-left: 15px;
@@ -25,11 +17,17 @@
 	}
 	ins {color:#00A000}
 	del {color:#A00000}
-    address {text-align:right;}
-    h1 {text-align:center;}
-    span.comment {color:#C80000;}
+	address {text-align:right;}
+	h1 {text-align:center;}
 	code {white-space:pre;}
+	@media (prefers-color-scheme: dark)
+	{
+		blockquote.note, p.note {background-color:#505050}
+		ins {color:#88FF88}
+		del {color:#FF5555}
+	}
 	</style>
+
 </head>
 <body>
 

--- a/date.html
+++ b/date.html
@@ -4,20 +4,17 @@
 <head>
 	<title>date</title>
 
+	<meta name="color-scheme" content="light dark" />
 	<style>
-	p {text-align:justify}
-	li {text-align:justify}
-	blockquote.note
-	{
-		background-color:#E0E0E0;
-		padding-left: 15px;
-		padding-right: 15px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-	}
+	li, p {text-align:justify}
 	ins {color:#00A000}
 	del {color:#A00000}
 	code {white-space:pre;}
+	@media (prefers-color-scheme: dark)
+	{
+		ins {color:#88FF88}
+		del {color:#FF5555}
+	}
 	</style>
 </head>
 <body>

--- a/islamic.html
+++ b/islamic.html
@@ -4,20 +4,17 @@
 <head>
 	<title>islamic</title>
 
+	<meta name="color-scheme" content="light dark" />
 	<style>
-	p {text-align:justify}
-	li {text-align:justify}
-	blockquote.note
-	{
-		background-color:#E0E0E0;
-		padding-left: 15px;
-		padding-right: 15px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-	}
+	li, p {text-align:justify}
 	ins {color:#00A000}
 	del {color:#A00000}
 	code {white-space:pre;}
+	@media (prefers-color-scheme: dark)
+	{
+		ins {color:#88FF88}
+		del {color:#FF5555}
+	}
 	</style>
 </head>
 <body>

--- a/iso_week.html
+++ b/iso_week.html
@@ -4,20 +4,17 @@
 <head>
 	<title>iso_week</title>
 
+	<meta name="color-scheme" content="light dark" />
 	<style>
-	p {text-align:justify}
-	li {text-align:justify}
-	blockquote.note
-	{
-		background-color:#E0E0E0;
-		padding-left: 15px;
-		padding-right: 15px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-	}
+	li, p {text-align:justify}
 	ins {color:#00A000}
 	del {color:#A00000}
 	code {white-space:pre;}
+	@media (prefers-color-scheme: dark)
+	{
+		ins {color:#88FF88}
+		del {color:#FF5555}
+	}
 	</style>
 </head>
 <body>

--- a/julian.html
+++ b/julian.html
@@ -4,20 +4,17 @@
 <head>
 	<title>julian</title>
 
+	<meta name="color-scheme" content="light dark" />
 	<style>
-	p {text-align:justify}
-	li {text-align:justify}
-	blockquote.note
-	{
-		background-color:#E0E0E0;
-		padding-left: 15px;
-		padding-right: 15px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-	}
+	li, p {text-align:justify}
 	ins {color:#00A000}
 	del {color:#A00000}
 	code {white-space:pre;}
+	@media (prefers-color-scheme: dark)
+	{
+		ins {color:#88FF88}
+		del {color:#FF5555}
+	}
 	</style>
 </head>
 <body>

--- a/tz.html
+++ b/tz.html
@@ -4,20 +4,17 @@
 <head>
 	<title>Time Zone Database Parser</title>
 
+	<meta name="color-scheme" content="light dark" />
 	<style>
-	p {text-align:justify}
-	li {text-align:justify}
-	blockquote.note
-	{
-		background-color:#E0E0E0;
-		padding-left: 15px;
-		padding-right: 15px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-	}
+	li, p {text-align:justify}
 	ins {color:#00A000}
 	del {color:#A00000}
 	code {white-space:pre;}
+	@media (prefers-color-scheme: dark)
+	{
+		ins {color:#88FF88}
+		del {color:#FF5555}
+	}
 	</style>
 </head>
 <body>


### PR DESCRIPTION
This patch updates the html documentation to add the color-scheme meta element, signalling light and dark color scheme support, and updating the inline CSS styles to override some colors when dark mode is active, to make sure that the document is always readable.

I've also cleaned up a bit the CSS styles, but without functional changes.

I've only updated the latest standard revision (r7), but please let me know if I should revert changes to that file.

Here's how it looks on my system; the dark scheme is provided by the browser:

![image](https://user-images.githubusercontent.com/34214253/211171855-25b4db64-d86d-475f-80b9-5908de40aa00.png)

![image](https://user-images.githubusercontent.com/34214253/211171966-d02fd52d-05c9-487b-aba5-e84b78c4de85.png)

PS: to be clear, the page is rendered in dark mode only if the user has set dark mode in the browser/system settings