### PR TITLE
slow init of vector of (tz) dates

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -293,7 +293,8 @@ struct zoned_traits<const time_zone*>
     const time_zone*
     default_zone()
     {
-        return date::locate_zone("Etc/UTC");
+      static const time_zone* result = date::locate_zone("Etc/UTC");
+      return result;
     }
 
 #if HAS_STRING_VIEW


### PR DESCRIPTION
Creating a large vector of localized dates is painfully slow, because a lookup is needed each time (especially in debug mode).
Caching the default result solves the issue.