### PR TITLE
Fix compilation when MISSING_LEAP_SECONDS is set to true

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2820,6 +2820,7 @@ find_read_and_leap_seconds()
         }
         return leap_seconds;
     }
+#if !MISSING_LEAP_SECONDS
     in.clear();
     in.open(get_tz_dir() + std::string(1, folder_delimiter) + "right/UTC",
                      std::ios_base::binary);
@@ -2834,6 +2835,7 @@ find_read_and_leap_seconds()
     {
         return load_just_leaps(in);
     }
+#endif
     return {};
 }
 


### PR DESCRIPTION
When define MISSING_LEAP_SECONDS throws compile time `error: 'load_just_leaps' was not declared in this scope`
when find_read_and_leap_seconds tries to call load_just_leaps which surrounded with #if !MISSING_LEAP_SECONDS 
This commit surrounds call to load_just_leaps