### PR TITLE
detect current zone on OpenWRT systems

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3933,6 +3933,25 @@ sniff_realpath(const char* timezone)
 const time_zone*
 tzdb::current_zone() const
 {
+    // On OpenWRT we need to check /etc/config/system
+    // It will have a line with the following structure
+    //   ...
+    //   option zoneName 'Europe/Berlin'
+    //   ...
+    {
+        std::ifstream timezone_file("/etc/config/system");
+        if (timezone_file.is_open())
+        {
+            for(std::string result; std::getline(timezone_file, result);) {
+                std::string findStr = "option zoneName '";
+                size_t startPos = result.find(findStr);
+                if (startPos != std::string::npos) {
+                    size_t endPos = result.find("'", startPos + findStr.size());
+                    return locate_zone(result.substr(startPos + findStr.size(), endPos - startPos - findStr.size()));
+                }
+            }
+        }
+    }
     // On some OS's a file called /etc/localtime may
     // exist and it may be either a real file
     // containing time zone details or a symlink to such a file.


### PR DESCRIPTION
Similar to buildroot we might want to detect the timezone on OpenWRT systems which are also quite popular. (I am not sure if i remember correctly that you didn't really want more systems in the detection part - if so, i just want to provide it for anyone that searches it, so he/she/it can apply a nice ready-to-go patch.)

Thanks for the great library!