### PR TITLE
Fixed build for WinRT and Android

### DIFF
--- a/include/date/tz.h
+++ b/include/date/tz.h
@@ -49,7 +49,7 @@
 
 #ifndef HAS_REMOTE_API
 #  if USE_OS_TZDB == 0
-#    ifdef _WIN32
+#    if defined _WIN32 || defined __ANDROID__
 #      define HAS_REMOTE_API 0
 #    else
 #      define HAS_REMOTE_API 1

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -118,6 +118,9 @@
 // the current time zone. On Win32 windows.h provides a means to do it.
 // gcc/mingw supports unistd.h on Win32 but MSVC does not.
 
+#ifdef __ANDROID__
+#  define INSTALL .
+#endif
 #ifdef _WIN32
 #  ifdef WINAPI_FAMILY
 #    include <winapifamily.h>

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -183,20 +183,6 @@ static CONSTDATA char folder_delimiter = '/';
 #if !USE_OS_TZDB
 
 #  ifdef _WIN32
-#    ifndef WINRT
-
-namespace
-{
-    struct task_mem_deleter
-    {
-        void operator()(wchar_t buf[])
-        {
-            if (buf != nullptr)
-                CoTaskMemFree(buf);
-        }
-    };
-    using co_task_mem_ptr = std::unique_ptr<wchar_t[], task_mem_deleter>;
-}
 
 static
 std::wstring
@@ -225,6 +211,21 @@ convert_utf8_to_utf16(const std::string& s)
     }
 
     return out;
+}
+
+#    ifndef WINRT
+
+namespace
+{
+    struct task_mem_deleter
+    {
+        void operator()(wchar_t buf[])
+        {
+            if (buf != nullptr)
+                CoTaskMemFree(buf);
+        }
+    };
+    using co_task_mem_ptr = std::unique_ptr<wchar_t[], task_mem_deleter>;
 }
 
 // We might need to know certain locations even if not using the remote API,


### PR DESCRIPTION
1. Code under #ifdef WINRT uses convert_utf8_to_utf16() function too, so this func should not be defined under #ifndef WINRT

2. Android has no curl.h, wordexp.h and even tz database is in non-standard binary format, but library still could be used on Android with user supplied tz database, if some defines are set to more reasonable defaults.