### PR TITLE
Add ability to specify timezone database location via environment variable

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -81,6 +81,9 @@
 #  endif  // __MINGW32__
 
 #  include <windows.h>
+#  if !defined(S_ISDIR) && defined(S_IFMT) && defined(_S_IFDIR)
+#    define S_ISDIR(m) (((m) & S_IFMT) == _S_IFDIR)
+#  endif
 #endif  // _WIN32
 
 #include "date/tz_private.h"
@@ -411,6 +414,14 @@ access_install()
     #undef STRINGIZE
 #endif  // !INSTALL
 
+    {
+        static char* tz_local_env = getenv("TZDATA");
+        if (tz_local_env != nullptr) {
+            static std::string tz_local_env_s = tz_local_env;
+            return tz_local_env_s;
+        }
+    }
+
     return install;
 }
 
@@ -464,6 +475,14 @@ discover_tz_dir()
 #  ifndef __APPLE__
     CONSTDATA auto tz_dir_default = "/usr/share/zoneinfo";
     CONSTDATA auto tz_dir_buildroot = "/usr/share/zoneinfo/uclibc";
+
+    {
+        static char* tz_local_env = getenv("TZDATA");
+        if (tz_local_env != nullptr) {
+            static std::string tz_local_env_s = tz_local_env;
+            return tz_local_env_s;
+        }
+    }
 
     // Check special path which is valid for buildroot with uclibc builds
     if(stat(tz_dir_buildroot, &sb) == 0 && S_ISDIR(sb.st_mode))


### PR DESCRIPTION
This adds the ability for a user to populate the TZDATA environment variable to specify the location in which to look for the timezone database, which allows for a runtime query of this location. Without this, date currently only supports compile time determination of the database location.

This facilitates the ability to:
* Use a timezone database provided by a package manager
* Keep the timezone database up to date without re-compilation
* Be flexible about where the timezone database is stored

This is a simplification of https://github.com/HowardHinnant/date/pull/611, removing windows support for a zic-compiled binary database, so that it only adds environmental variable features.

Closes #788