### PR TITLE
Update gitattributes of zip files to binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+*zip -text -diff
+


### PR DESCRIPTION
Fixes #815. I can still unzip the files then. (The extracted text file has Unix EOL conventions.)