### PR TITLE
Support tz databases from release 2023d and newer by adding new zonenow.tab file to ignore list

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2873,6 +2873,7 @@ init_tzdb()
                 strcmp(d->d_name, "version")      == 0      ||
                 strcmp(d->d_name, "zone.tab")     == 0      ||
                 strcmp(d->d_name, "zone1970.tab") == 0      ||
+                strcmp(d->d_name, "zonenow.tab")  == 0      ||
                 strcmp(d->d_name, "tzdata.zi")    == 0      ||
                 strcmp(d->d_name, "leapseconds")  == 0      ||
                 strcmp(d->d_name, "leap-seconds.list") == 0   )


### PR DESCRIPTION
date's internal init_tzdb function iterates through the files provided by the tz database, and init_tzdb contains a list of files that should not be interpreted as being in TZif format.

The 2023d release of the tz database added a new file that is not in TZif format, zonenow.tab. However, this file had not been added to the ignore list.

This caused date to intepret the zonenow.tab file as a TZif file, which caused assertions to fire in debug mode if the user attempted to load its associated time_zone, causing load_header() to be invoked on the file, which would find that it did not contain a 'TZif' magic number.

This commit addresses the issue by adding the file to the ignore list.

The announcement on the tz database mailing list which describes the addition of zonenow.tab can be found at this link:

https://mm.icann.org/pipermail/tz-announce/2023-December/000080.html