### PR TITLE
Fix current_zone not working on buildroot+glibc target - refs #846

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -4187,6 +4187,8 @@ sniff_realpath(const char* timezone)
     if (rp.get() == nullptr)
         throw system_error(errno, system_category(), "realpath() failed");
     auto result = extract_tz_name(rp.get());
+    if (result.find("posix") == 0)
+        return false;
     return result != "posixrules";
 }
 


### PR DESCRIPTION
The layout for timezones, on these targets, is
`/usr/share/zoneinfo/posix/Europe/Paris` instead of `/usr/share/zoneinfo/Europe/Paris`.

`/usr/share/zoneinfo/Europe/Paris` exists and is a symlink to `/usr/share/zoneinfo/posix/Europe/Paris`.

`/etc/localtime` correctly links to `/usr/share/zoneinfo/Europe/Paris`, so `readlink` must be used instead of `realpath`.