### PR TITLE
Do not try loading leap seconds on MacOS / OSX / IOS with system TZDB

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -87,6 +87,9 @@
 
 #ifdef __APPLE__
 #  include "date/ios.h"
+#  if USE_OS_TZDB
+#    define MISSING_LEAP_SECONDS 1
+#  endif // USE_OS_TZDB
 #else
 #  define TARGET_OS_IPHONE 0
 #  define TARGET_OS_SIMULATOR 0


### PR DESCRIPTION
It is known from date documentation that Apple chose not to provide leap second info in compiled zoneinfo files shipped with OSX and iOS.

This PR sets `MISSING_LEAP_SECONDS` definition if both `__APPLE__` and `USE_OS_TZDB` is set.

Tested on Kodi builds targeting OSX 10.14 and 10.15
