### PR TITLE
improve `test_fail.sh`

### DIFF
--- a/test_fail.sh
+++ b/test_fail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo $1
 eval $1
@@ -7,4 +7,3 @@ if [ $? -eq 0 ]; then
 	exit 0;
 fi
 exit 1;
-

--- a/test_fail.sh
+++ b/test_fail.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
+# show what is to be run
 echo $1
-eval $1
-
-if [ $? -eq 0 ]; then
-	exit 0;
-fi
-exit 1;
+# run the command
+eval $1 || exit 1 # if fails, return 1


### PR DESCRIPTION
The first change is a bugfix -- bash is not available on any system and the path to it is not always the same.
Calling `/usr/bin/env bash` is a good fix for that, but the script is not using any bash-specific stuff so I have made it call `/bin/sh` which is a standard location for the POSIX sh.

In the second commit I have simplified the code while keeping the functionality:
```console
$ ./test_fail.sh true && echo ok || echo bad
true
ok
$ ./test_fail.sh false && echo ok || echo bad
false
bad

```