### PR TITLE
test/solar_hijri_test/parse.pass.cpp: specify unsigned type in loop

### DIFF
--- a/test/solar_hijri_test/parse.pass.cpp
+++ b/test/solar_hijri_test/parse.pass.cpp
@@ -215,7 +215,7 @@ test_g() {
   static_assert(sizeof(ymdd)/sizeof(ymdd[0]) == sizeof(ymdh)/sizeof(ymdh[0]), "");
   static_assert(sizeof(ymdd)/sizeof(ymdd[0]) == sizeof(leaps)/sizeof(leaps[0]), "");
 
-  for (auto i = 0; i < sizeof(ymdd)/sizeof(ymdd[0]); ++i)
+  for (auto i = 0u; i < sizeof(ymdd)/sizeof(ymdd[0]); ++i)
   {
     assert(solar_hijri::year_month_day{ymdd[i]} == ymdh[i]);
     assert(ymdd[i] == date::year_month_day{ymdh[i]});


### PR DESCRIPTION
This fixes the warning (on amd64):
```
parse.pass.cpp:218:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  218 |   for (auto i = 0; i < sizeof(ymdd)/sizeof(ymdd[0]); ++i)
      |                    ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```