### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@
      )
      FetchContent_MakeAvailable(date_src)
      ...
-     target_link_libraries (my_target PRIVATE date::date)
+     target_link_libraries (my_target PRIVATE date::date date::date-tz)
+     
 
 #]===================================================================]
 


### PR DESCRIPTION
In order to utilize the timezone parser in other CMake projects, one must include date::date-tz in their target_link_libraries (I found this out after a week of debugging).