### PR TITLE
Address remaining 'whitespace in literal' upsetting clang++-20

### DIFF
--- a/include/date/islamic.h
+++ b/include/date/islamic.h
@@ -758,8 +758,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last&
 inline namespace literals
 {
 
-CONSTCD11 islamic::day  operator "" _d(unsigned long long d) NOEXCEPT;
-CONSTCD11 islamic::year operator "" _y(unsigned long long y) NOEXCEPT;
+CONSTCD11 islamic::day  operator ""_d(unsigned long long d) NOEXCEPT;
+CONSTCD11 islamic::year operator ""_y(unsigned long long y) NOEXCEPT;
 
 }  // inline namespace literals
 #endif // !defined(_MSC_VER) || (_MSC_VER >= 1900)
@@ -1339,7 +1339,7 @@ inline namespace literals
 CONSTCD11
 inline
 islamic::day
-operator "" _d(unsigned long long d) NOEXCEPT
+operator ""_d(unsigned long long d) NOEXCEPT
 {
     return islamic::day{static_cast<unsigned>(d)};
 }
@@ -1347,7 +1347,7 @@ operator "" _d(unsigned long long d) NOEXCEPT
 CONSTCD11
 inline
 islamic::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return islamic::year(static_cast<int>(y));
 }

--- a/include/date/iso_week.h
+++ b/include/date/iso_week.h
@@ -747,7 +747,7 @@ inline namespace literals
 CONSTCD11
 inline
 iso_week::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return iso_week::year(static_cast<int>(y));
 }
@@ -755,7 +755,7 @@ operator "" _y(unsigned long long y) NOEXCEPT
 CONSTCD11
 inline
 iso_week::weeknum
-operator "" _w(unsigned long long wn) NOEXCEPT
+operator ""_w(unsigned long long wn) NOEXCEPT
 {
     return iso_week::weeknum(static_cast<unsigned>(wn));
 }

--- a/include/date/julian.h
+++ b/include/date/julian.h
@@ -758,8 +758,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last&
 inline namespace literals
 {
 
-CONSTCD11 julian::day  operator "" _d(unsigned long long d) NOEXCEPT;
-CONSTCD11 julian::year operator "" _y(unsigned long long y) NOEXCEPT;
+CONSTCD11 julian::day  operator ""_d(unsigned long long d) NOEXCEPT;
+CONSTCD11 julian::year operator ""_y(unsigned long long y) NOEXCEPT;
 
 // CONSTDATA julian::month jan{1};
 // CONSTDATA julian::month feb{2};
@@ -1333,7 +1333,7 @@ inline namespace literals
 CONSTCD11
 inline
 julian::day
-operator "" _d(unsigned long long d) NOEXCEPT
+operator ""_d(unsigned long long d) NOEXCEPT
 {
     return julian::day{static_cast<unsigned>(d)};
 }
@@ -1341,7 +1341,7 @@ operator "" _d(unsigned long long d) NOEXCEPT
 CONSTCD11
 inline
 julian::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return julian::year(static_cast<int>(y));
 }

--- a/include/date/solar_hijri.h
+++ b/include/date/solar_hijri.h
@@ -792,8 +792,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last&
 inline namespace literals
 {
 
-CONSTCD11 solar_hijri::day  operator "" _d(unsigned long long d) NOEXCEPT;
-CONSTCD11 solar_hijri::year operator "" _y(unsigned long long y) NOEXCEPT;
+CONSTCD11 solar_hijri::day  operator ""_d(unsigned long long d) NOEXCEPT;
+CONSTCD11 solar_hijri::year operator ""_y(unsigned long long y) NOEXCEPT;
 
 }  // inline namespace literals
 #endif // !defined(_MSC_VER) || (_MSC_VER >= 1900)
@@ -1364,7 +1364,7 @@ inline namespace literals
 CONSTCD11
 inline
 solar_hijri::day
-operator "" _d(unsigned long long d) NOEXCEPT
+operator ""_d(unsigned long long d) NOEXCEPT
 {
     return solar_hijri::day{static_cast<unsigned>(d)};
 }
@@ -1372,7 +1372,7 @@ operator "" _d(unsigned long long d) NOEXCEPT
 CONSTCD11
 inline
 solar_hijri::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return solar_hijri::year(static_cast<int>(y));
 }


### PR DESCRIPTION
As just discussed in [a comment at the recently merged #869](https://github.com/HowardHinnant/date/pull/869#issuecomment-2702513324), the same issue is present in a few more places.  This simple PR tries to get these remaining instances.