### PR TITLE
Don't negate `toff` if we've already failed

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -7577,7 +7577,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                             }
                         }
                     }
-                    if (neg)
+                    if (neg && !is.fail())
                         toff = -toff;
                     checked_set(temp_offset, toff, not_a_offset, is);
                     command = nullptr;


### PR DESCRIPTION
I happened to notice that if you try to parse something horrible like this

```
1970-01-01T00:00:00-a5:00[America/New_York]
```

(note the `a` in the time zone offset)

with this format string: `"%Y-%m-%dT%H:%M:%S%Ez[%Z]"`,

then you can end up with undefined behavior when parsing the `%z` bit.

- The `-` is handled up front, setting `neg = true`
- The `a` prevents `read()` from succeeding, so `toff` is never updated
- Since `neg = true`, `toff = -toff` is called.

This combination poses a problem because:

```
toff = not_a_offset = minutes::min() = long min
```

And due to two's complement, calling `-` on this minimum value is undefined behavior.

The easy solution seems to be to just not update `toff` if you know you're already in a fail state, this seems consistent with what `read_signed()` does too.

---

This was detected with clang under UBSAN and gives this runtime error:

> runtime error: negation of -9223372036854775808 cannot be represented in type 'rep' (aka 'long'); cast to an unsigned type to negate this value to itself

And indeed if you step through it you can see it hit this branch

<img width="525" alt="Screenshot 2025-03-17 at 10 17 29 AM" src="https://github.com/user-attachments/assets/2b89ef5d-c033-4f33-8d0d-9b0dc59ca1c5" />

CI workflow where it showed up:
https://github.com/gaborcsardi/clock/actions/runs/13901011041/job/38892525902#step:6:682

