### PR TITLE
Don't fail on nearly blank lines

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3838,6 +3838,10 @@ init_tzdb()
                 std::istringstream in(line);
                 std::string word;
                 in >> word;
+                if (word.empty())
+                {
+                  continue;
+                }
                 tolower(word);
                 if (is_prefix_of(word, "rule"))
                 {


### PR DESCRIPTION
If a line only contains tabs the word will be an empty string. And then is_prefix_of does match on rule, beacuse it's substring of length 0 is also an empty string. Subsequently the parsing of the rule fails with an exception.