### PR TITLE
compile_fail.sh: use sh for new files

### DIFF
--- a/compile_fail.sh
+++ b/compile_fail.sh
@@ -7,9 +7,9 @@ export BUILD_COMMAND=$@
 eval ${BUILD_COMMAND} >/dev/null 2>/dev/null
 
 if [ $? -eq 0 ]; then
-	echo -ne "#!/bin/bash\nexit 1;" > ${TEST_BIN_NAME}
+	echo -ne "#!/bin/sh\nexit 1;" > ${TEST_BIN_NAME}
 else
-	echo -ne "#!/bin/bash\nexit 0;" > ${TEST_BIN_NAME}
+	echo -ne "#!/bin/sh\nexit 0;" > ${TEST_BIN_NAME}
 fi
 chmod u+x ${TEST_BIN_NAME}
 exit 0;


### PR DESCRIPTION
it just creates a shell script to exit from. sh is enough for that.