### PR TITLE
compile_fail.sh: do not `exit 0` explicitly

### DIFF
--- a/compile_fail.sh
+++ b/compile_fail.sh
@@ -12,5 +12,3 @@ else
 	echo -ne "#!/bin/bash\nexit 0;" > ${TEST_BIN_NAME}
 fi
 chmod u+x ${TEST_BIN_NAME}
-exit 0;
-


### PR DESCRIPTION
That's the default