### PR TITLE
fix: add quotes to all std::system invocations in tz 

### DIFF
--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -3309,7 +3309,7 @@ remove_folder_and_subfolders(const std::string& folder)
 #    endif  // !USE_SHELL_API
 #  else   // !_WIN32
 #    if USE_SHELL_API
-    return std::system(("rm -R " + folder).c_str()) == EXIT_SUCCESS;
+    return std::system(("rm -R \"" + folder + "\"").c_str()) == EXIT_SUCCESS;
 #    else // !USE_SHELL_API
     struct dir_deleter {
         dir_deleter() {}
@@ -3375,7 +3375,7 @@ make_directory(const std::string& folder)
 #    endif // !USE_SHELL_API
 #  else  // !_WIN32
 #    if USE_SHELL_API
-    return std::system(("mkdir -p " + folder).c_str()) == EXIT_SUCCESS;
+    return std::system(("mkdir -p \"" + folder + "\"").c_str()) == EXIT_SUCCESS;
 #    else  // !USE_SHELL_API
     return mkdir(folder.c_str(), 0777) == 0;
 #    endif  // !USE_SHELL_API
@@ -3397,7 +3397,7 @@ delete_file(const std::string& file)
 #    endif // !USE_SHELL_API
 #  else  // !_WIN32
 #    if USE_SHELL_API
-    return std::system(("rm " + file).c_str()) == EXIT_SUCCESS;
+    return std::system(("rm \"" + file + "\"").c_str()) == EXIT_SUCCESS;
 #    else // !USE_SHELL_API
     return unlink(file.c_str()) == 0;
 #    endif // !USE_SHELL_API
@@ -3632,7 +3632,7 @@ bool
 extract_gz_file(const std::string&, const std::string& gz_file, const std::string&)
 {
 #    if USE_SHELL_API
-    bool unzipped = std::system(("tar -xzf " + gz_file + " -C " + get_install()).c_str()) == EXIT_SUCCESS;
+    bool unzipped = std::system(("tar -xzf \"" + gz_file + "\" -C \"" + get_install() + "\"").c_str()) == EXIT_SUCCESS;
 #    else  // !USE_SHELL_API
     const char prog[] = {"/usr/bin/tar"};
     const char*const args[] =


### PR DESCRIPTION
This PR adds quotes around all paths used when using std::system.
This allows paths to contain spaces
