### PR TITLE
fix(build): propagate HAS_STRING_VIEW=1 to library consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,12 @@ if( BUILD_TZ_LIB )
         find_package( CURL REQUIRED )
         target_link_libraries( date-tz PRIVATE CURL::libcurl )
     endif( )
+
+    if ( DISABLE_STRING_VIEW )
+        target_compile_definitions( date-tz INTERFACE HAS_STRING_VIEW=0 )
+    else()
+        target_compile_definitions( date-tz INTERFACE HAS_STRING_VIEW=1 )
+    endif()
 endif( )
 
 #[===================================================================[


### PR DESCRIPTION
Ensure that both the library and its clients use the same ABI for locate_zone (std::string_view overload). Previously, the macro was defined only when building the library, causing linker errors for projects that consumed the shared library without the same define.

Add target_compile_definitions(date-tz INTERFACE HAS_STRING_VIEW=1) to force consistent definition across all dependencies.

Ref: https://github.com/HowardHinnant/date/issues/398