### PR TITLE
fix: Fix incorrect HAS_STRING_VIEW detection for C++11 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,7 @@ else()
   target_compile_definitions( date INTERFACE ONLY_C_LOCALE=0 )
 endif()
 if ( DISABLE_STRING_VIEW )
-  target_compile_definitions( date INTERFACE HAS_STRING_VIEW=0 -DHAS_DEDUCTION_GUIDES=0 )
-else()
-  target_compile_definitions( date INTERFACE HAS_STRING_VIEW=1 )
+  target_compile_definitions( date INTERFACE HAS_STRING_VIEW=0 HAS_DEDUCTION_GUIDES=0 )
 endif()
 
 #[===================================================================[


### PR DESCRIPTION
## fix issue : https://github.com/HowardHinnant/date/issues/916

<img width="2349" height="1961" alt="image" src="https://github.com/user-attachments/assets/9377ea6b-2345-43bc-9b55-1d39c401c0b6" />
