### PR TITLE
fix: signed-int-overflow in `date::from_stream` width parsing

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -7637,7 +7637,12 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     {
                         width = static_cast<char>(*fmt) - '0';
                         while ('0' <= fmt[1] && fmt[1] <= '9')
-                            width = 10*width + static_cast<char>(*++fmt) - '0';
+                        {
+                            const int digit = static_cast<char>(*++fmt) - '0';
+                            if (width > (numeric_limits<int>::max() - digit) / 10)
+                                break;
+                            width = 10*width + digit;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
This PR attempts to fix [#918](https://github.com/HowardHinnant/date/issues/918#issue-5077552571)

## Problem

`date::from_stream` parses `strftime`/`strptime`-style format strings. When it encounters `%` followed by digits, it interprets those digits as a width specifier, accumulated into a plain `int` (`auto width = -1;`, line 6605):

```cpp
// include/date/date.h:7636-7641
if (width == -1 && modified == CharT{} && '0' <= *fmt && *fmt <= '9')
{
    width = static_cast<char>(*fmt) - '0';
    while ('0' <= fmt[1] && fmt[1] <= '9')
        width = 10*width + static_cast<char>(*++fmt) - '0';  // UB on overflow
}
```

The loop has no overflow guard. With sixteen consecutive `'5'` digits the accumulator reaches `555555555` and the next `10 * 555555555 = 5555555550` exceeds `INT_MAX` (2147483647). Signed integer overflow is undefined behavior per C++ [expr.pre]/4; UndefinedBehaviorSanitizer flags and aborts on it:

```
date.h:7640:39: runtime error: signed integer overflow: 10 * 555555555 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior date.h:7640:39
```

The overflowed `width` also propagates into the read-width argument of every field parser that consults it, via `width == -1 ? N : static_cast<unsigned>(width)` (e.g. lines 6908, 6963, 6989).

This is a library bug, not API misuse: the PoC uses the documented public API directly (`std::istringstream` + default-constructed `date::year_month_day` + `date::from_stream(is, fmt, ymd)`), and there is no API contract restricting the length or content of the format string. The library is responsible for handling arbitrary format strings without invoking UB.

## Fix

Guard the multiply before it can overflow, breaking out of the digit loop so `width` stays at the largest in-range value accumulated so far:

```cpp
// include/date/date.h — width loop
if (width == -1 && modified == CharT{} && '0' <= *fmt && *fmt <= '9')
{
    width = static_cast<char>(*fmt) - '0';
    while ('0' <= fmt[1] && fmt[1] <= '9')
    {
        const int digit = static_cast<char>(*++fmt) - '0';
        if (width > (numeric_limits<int>::max() - digit) / 10)
            break;  // prevent signed overflow
        width = 10*width + digit;
    }
}
```

`numeric_limits` is already in use elsewhere in the file, so no new include is required. On overflow the directive proceeds with a (large) in-range width — equivalent to a caller legitimately writing e.g. `%999999999Y` — which reads as many digits as the stream offers: bounded, no UB, no infinite loop.

## Verification

### Sanitizer rebuild

Rebuilt the library with AddressSanitizer and UndefinedBehaviorSanitizer to
confirm the overflow is gone and no UB remains:

```bash
export CC=clang CXX=clang++
export CFLAGS="-fsanitize=address,undefined -fno-sanitize=function -fsanitize-address-use-after-scope -g -O0 -fstandalone-debug -fPIC -fno-inline -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
export CXXFLAGS="$CFLAGS"
cmake -S "$SRC" -B /tmp/build_tmp \
      -DCMAKE_INSTALL_PREFIX="$WORK" \
      -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
      -DCMAKE_C_FLAGS="$CFLAGS -g" -DCMAKE_CXX_FLAGS="$CXXFLAGS -g" \
      -DBUILD_SHARED_LIBS=OFF -DBUILD_TZ_LIB=ON \
      -DUSE_SYSTEM_TZ_DB=ON -DMANUAL_TZ_DB=OFF \
      -DENABLE_DATE_TESTING=OFF -DENABLE_DATE_INSTALL=ON
cmake --build /tmp/build_tmp -j$(nproc)
cmake --install /tmp/build_tmp
```

### Before fix

```
date.h:7640:39: runtime error: signed integer overflow:
10 * 555555555 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior date.h:7640:39   (exit 1)
```

### After fix

(clean exit, code 0 — no sanitizer errors)

### PoC test

```bash
clang++ -g -O0 -fsanitize=address,undefined \
    -I"$WORK/include" poc.cpp -o poc \
    -Wl,--start-group "$WORK"/lib/lib*.a -Wl,--end-group
./poc   # "%5555555555555555U" → previously tripped UBSan; now exits 0 clean
```

### Regression check

A/B compared the original (unpatched) and patched headers across normal parsing and bounded-width specifiers:

| format              | original header | patched header |
|---------------------|-----------------|----------------|
| `%F` → `2024-03-15` | `2024-3-15`, fail=0 | `2024-3-15`, fail=0 |
| `%Y` / `%4Y`        | year=1999, fail=1 | year=1999, fail=1 (identical) |
| `%5555555555555555U`| UBSan abort (exit 1) | clean exit 0 |

The `%Y`/`%4Y` `fail=1` is pre-existing behavior (a single `%Y` specifier against a stream containing only `"2024"` does not satisfy `year_month_day` validation) and is unchanged by the fix — confirming normal parsing is byte-for-byte identical; the fix is strictly additive, only preventing the overflow.